### PR TITLE
throw exception on overflow for binary operations

### DIFF
--- a/src/main/java/org/elasticsearch/plan/a/Analyzer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Analyzer.java
@@ -827,9 +827,9 @@ class Analyzer extends PlanABaseVisitor<Void> {
             
             if (ctx.MUL() != null) {
                 if (tmd == TypeMetadata.INT) {
-                    binaryemd.preConst = (int)expremd0.postConst * (int)expremd1.postConst;
+                    binaryemd.preConst = Math.multiplyExact((int)expremd0.postConst, (int)expremd1.postConst);
                 } else if (tmd == TypeMetadata.LONG) {
-                    binaryemd.preConst = (long)expremd0.postConst * (long)expremd1.postConst;
+                    binaryemd.preConst = Math.multiplyExact((long)expremd0.postConst, (long)expremd1.postConst);
                 } else if (tmd == TypeMetadata.FLOAT) {
                     binaryemd.preConst = (float)expremd0.postConst * (float)expremd1.postConst;
                 } else if (tmd == TypeMetadata.DOUBLE) {
@@ -839,9 +839,9 @@ class Analyzer extends PlanABaseVisitor<Void> {
                 }
             } else if (ctx.DIV() != null) {
                 if (tmd == TypeMetadata.INT) {
-                    binaryemd.preConst = (int)expremd0.postConst / (int)expremd1.postConst;
+                    binaryemd.preConst = Utility.divideWithoutOverflow((int)expremd0.postConst, (int)expremd1.postConst);
                 } else if (tmd == TypeMetadata.LONG) {
-                    binaryemd.preConst = (long)expremd0.postConst / (long)expremd1.postConst;
+                    binaryemd.preConst = Utility.divideWithoutOverflow((long)expremd0.postConst, (long)expremd1.postConst);
                 } else if (tmd == TypeMetadata.FLOAT) {
                     binaryemd.preConst = (float)expremd0.postConst / (float)expremd1.postConst;
                 } else if (tmd == TypeMetadata.DOUBLE) {
@@ -863,9 +863,9 @@ class Analyzer extends PlanABaseVisitor<Void> {
                 }
             } else if (ctx.ADD() != null) {
                 if (tmd == TypeMetadata.INT) {
-                    binaryemd.preConst = (int)expremd0.postConst + (int)expremd1.postConst;
+                    binaryemd.preConst = Math.addExact((int)expremd0.postConst, (int)expremd1.postConst);
                 } else if (tmd == TypeMetadata.LONG) {
-                    binaryemd.preConst = (long)expremd0.postConst + (long)expremd1.postConst;
+                    binaryemd.preConst = Math.addExact((long)expremd0.postConst, (long)expremd1.postConst);
                 } else if (tmd == TypeMetadata.FLOAT) {
                     binaryemd.preConst = (float)expremd0.postConst + (float)expremd1.postConst;
                 } else if (tmd == TypeMetadata.DOUBLE) {
@@ -875,9 +875,9 @@ class Analyzer extends PlanABaseVisitor<Void> {
                 }
             } else if (ctx.SUB() != null) {
                 if (tmd == TypeMetadata.INT) {
-                    binaryemd.preConst = (int)expremd0.postConst - (int)expremd1.postConst;
+                    binaryemd.preConst = Math.subtractExact((int)expremd0.postConst, (int)expremd1.postConst);
                 } else if (tmd == TypeMetadata.LONG) {
-                    binaryemd.preConst = (long)expremd0.postConst - (long)expremd1.postConst;
+                    binaryemd.preConst = Math.subtractExact((long)expremd0.postConst, (long)expremd1.postConst);
                 } else if (tmd == TypeMetadata.FLOAT) {
                     binaryemd.preConst = (float)expremd0.postConst - (float)expremd1.postConst;
                 } else if (tmd == TypeMetadata.DOUBLE) {

--- a/src/main/java/org/elasticsearch/plan/a/Utility.java
+++ b/src/main/java/org/elasticsearch/plan/a/Utility.java
@@ -195,6 +195,32 @@ public class Utility {
     public static char doubleToChar(final Double value) {
         return (char)value.doubleValue();
     }
+    
+    // although divide by zero is guaranteed, the special overflow case is not caught.
+    // its not needed for remainder because it is not possible there.
+    // see https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.17.2
+    
+    /**
+     * Integer divide without overflow
+     * @throws ArithmeticException on overflow or divide-by-zero
+     */
+    public static int divideWithoutOverflow(int x, int y) {
+       if (x == Integer.MIN_VALUE && y == -1) {
+           throw new ArithmeticException("integer overflow");
+       }
+       return x / y;
+    }
+    
+    /**
+     * Long divide without overflow
+     * @throws ArithmeticException on overflow or divide-by-zero
+     */
+    public static long divideWithoutOverflow(long x, long y) {
+        if (x == Long.MIN_VALUE && y == -1L) {
+            throw new ArithmeticException("integer overflow");
+        }
+        return x / y;
+     }
 
     private Utility() {}
 }

--- a/src/main/java/org/elasticsearch/plan/a/Writer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Writer.java
@@ -1189,16 +1189,16 @@ class Writer extends PlanABaseVisitor<Void> {
     void writeToStrings() {
         execute.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/StringBuilder", "toString", "()Ljava/lang/String;", false);
     }
-
+    
     void writeBinaryInstruction(final ParserRuleContext source, final TypeMetadata metadata, final int token) {
         switch (metadata) {
             case INT:
                 switch (token) {
-                    case MUL:   execute.visitInsn(Opcodes.IMUL);  break;
-                    case DIV:   execute.visitInsn(Opcodes.IDIV);  break;
+                    case MUL:   execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "multiplyExact", "(II)I", false);  break;
+                    case DIV:   execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "divideWithoutOverflow", "(II)I", false);  break;
                     case REM:   execute.visitInsn(Opcodes.IREM);  break;
-                    case ADD:   execute.visitInsn(Opcodes.IADD);  break;
-                    case SUB:   execute.visitInsn(Opcodes.ISUB);  break;
+                    case ADD:   execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "addExact", "(II)I", false);  break;
+                    case SUB:   execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "subtractExact", "(II)I", false);  break;
                     case LSH:   execute.visitInsn(Opcodes.ISHL);  break;
                     case USH:   execute.visitInsn(Opcodes.IUSHR); break;
                     case RSH:   execute.visitInsn(Opcodes.ISHR);  break;
@@ -1212,11 +1212,11 @@ class Writer extends PlanABaseVisitor<Void> {
                 break;
             case LONG:
                 switch (token) {
-                    case MUL:   execute.visitInsn(Opcodes.LMUL);  break;
-                    case DIV:   execute.visitInsn(Opcodes.LDIV);  break;
+                    case MUL:   execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "multiplyExact", "(JJ)J", false);  break;
+                    case DIV:   execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "divideWithoutOverflow", "(JJ)J", false);  break;
                     case REM:   execute.visitInsn(Opcodes.LREM);  break;
-                    case ADD:   execute.visitInsn(Opcodes.LADD);  break;
-                    case SUB:   execute.visitInsn(Opcodes.LSUB);  break;
+                    case ADD:   execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "addExact", "(JJ)J", false);  break;
+                    case SUB:   execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "subtractExact", "(JJ)J", false);  break;
                     case LSH:   execute.visitInsn(Opcodes.LSHL);  break;
                     case USH:   execute.visitInsn(Opcodes.LUSHR); break;
                     case RSH:   execute.visitInsn(Opcodes.LSHR);  break;

--- a/src/test/java/org/elasticsearch/plan/a/AdditionTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/AdditionTests.java
@@ -193,12 +193,26 @@ public class AdditionTests extends ScriptTestCase {
     }
   
     public void testOverflow() throws Exception {
-        assertEquals(Integer.MAX_VALUE + Integer.MAX_VALUE, exec("int x = 2147483647; int y = 2147483647; return x + y;"));
-        assertEquals(Long.MAX_VALUE + Long.MAX_VALUE, exec("long x = 9223372036854775807L; long y = 9223372036854775807L; return x + y;"));
+        try {
+            exec("int x = 2147483647; int y = 2147483647; return x + y;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("long x = 9223372036854775807L; long y = 9223372036854775807L; return x + y;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
     }
     
     public void testOverflowConst() throws Exception {
-        assertEquals(Integer.MAX_VALUE + Integer.MAX_VALUE, exec("return 2147483647 + 2147483647;"));
-        assertEquals(Long.MAX_VALUE + Long.MAX_VALUE, exec("return 9223372036854775807L + 9223372036854775807L;"));
+        try {
+            exec("return 2147483647 + 2147483647;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("return 9223372036854775807L + 9223372036854775807L;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
     }
 }

--- a/src/test/java/org/elasticsearch/plan/a/BasicExpressionTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/BasicExpressionTests.java
@@ -58,65 +58,6 @@ public class BasicExpressionTests extends ScriptTestCase {
         assertEquals(false, exec("bool v = false; return v;"));
     }
 
-    /** incrementing byte values */
-    public void testIncrementByte() {
-        assertEquals((byte)0, exec("byte x = (byte)0; return x++;"));
-        assertEquals((byte)0, exec("byte x = (byte)0; return x--;"));
-        assertEquals((byte)1, exec("byte x = (byte)0; return ++x;"));
-        assertEquals((byte)-1, exec("byte x = (byte)0; return --x;"));
-    }
-    
-    /** incrementing short values */
-    public void testIncrementShort() {
-        assertEquals((short)0, exec("short x = (short)0; return x++;"));
-        assertEquals((short)0, exec("short x = (short)0; return x--;"));
-        assertEquals((short)1, exec("short x = (short)0; return ++x;"));
-        assertEquals((short)-1, exec("short x = (short)0; return --x;"));
-    }
-
-    /** incrementing integer values */
-    public void testIncrementInt() {
-        assertEquals(0, exec("int x = 0; return x++;"));
-        assertEquals(0, exec("int x = 0; return x--;"));
-        assertEquals(1, exec("int x = 0; return ++x;"));
-        assertEquals(-1, exec("int x = 0; return --x;"));
-    }
-    
-    /** incrementing long values */
-    public void testIncrementLong() {
-        assertEquals(0L, exec("long x = 0; return x++;"));
-        assertEquals(0L, exec("long x = 0; return x--;"));
-        assertEquals(1L, exec("long x = 0; return ++x;"));
-        assertEquals(-1L, exec("long x = 0; return --x;"));
-    }
-    
-    /** incrementing float values */
-    public void testIncrementFloat() {
-        assertEquals(0F, exec("float x = 0F; return x++;"));
-        assertEquals(0F, exec("float x = 0F; return x--;"));
-        assertEquals(1F, exec("float x = 0F; return ++x;"));
-        assertEquals(-1F, exec("float x = 0F; return --x;"));
-    }
-    
-    /** incrementing double values */
-    public void testIncrementDouble() {
-        assertEquals(0D, exec("double x = 0.0; return x++;"));
-        assertEquals(0D, exec("double x = 0.0; return x--;"));
-        assertEquals(1D, exec("double x = 0.0; return ++x;"));
-        assertEquals(-1D, exec("double x = 0.0; return --x;"));
-    }
-
-    public void testUnary() {
-        assertEquals(false, exec("return !true;"));
-        assertEquals(true, exec("bool x = false; return !x;"));
-        assertEquals(-2, exec("return ~1;"));
-        assertEquals(-2, exec("byte x = 1; return ~x;"));
-        assertEquals(1, exec("return +1;"));
-        assertEquals(1.0, exec("double x = 1; return +x;"));
-        assertEquals(-1, exec("return -1;"));
-        assertEquals(-2, exec("short x = 2; return -x;"));
-    }
-
     public void testCast() {
         assertEquals(1, exec("return (int)true;"));
         assertEquals((byte)100, exec("double x = 100; return (byte)x;"));
@@ -181,11 +122,5 @@ public class BasicExpressionTests extends ScriptTestCase {
     public void testPrecedence() {
         assertEquals(2, exec("int x = 5; return (x+x)/x;"));
         assertEquals(true, exec("bool t = true, f = false; return t && (f || t);"));
-    }
-    
-    public void testNegationInt() throws Exception {
-        assertEquals(-1, exec("return -1;"));
-        assertEquals(1, exec("return -(-1);"));
-        assertEquals(0, exec("return -0;"));
     }
 }

--- a/src/test/java/org/elasticsearch/plan/a/DivisionTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/DivisionTests.java
@@ -144,4 +144,28 @@ public class DivisionTests extends ScriptTestCase {
             // divide by zero
         }
     }
+    
+    public void testOverflow() throws Exception {
+        try {
+            exec("int x = -2147483647 - 1; int y = -1; return x / y;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            System.out.println(exec("long x = -9223372036854775807L - 1L; long y = -1L; return x / y;"));
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testOverflowConst() throws Exception {
+        try {
+            exec("return (-2147483647 - 1) / -1;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("return (-9223372036854775807L - 1L) / -1L;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+    }
 }

--- a/src/test/java/org/elasticsearch/plan/a/MultiplicationTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/MultiplicationTests.java
@@ -125,12 +125,26 @@ public class MultiplicationTests extends ScriptTestCase {
     }
   
     public void testOverflow() throws Exception {
-        assertEquals(Integer.MAX_VALUE * Integer.MAX_VALUE, exec("int x = 2147483647; int y = 2147483647; return x * y;"));
-        assertEquals(Long.MAX_VALUE * Long.MAX_VALUE, exec("long x = 9223372036854775807L; long y = 9223372036854775807L; return x * y;"));
+        try {
+            exec("int x = 2147483647; int y = 2147483647; return x * y;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("long x = 9223372036854775807L; long y = 9223372036854775807L; return x * y;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
     }
     
     public void testOverflowConst() throws Exception {
-        assertEquals(Integer.MAX_VALUE * Integer.MAX_VALUE, exec("return 2147483647 * 2147483647;"));
-        assertEquals(Long.MAX_VALUE * Long.MAX_VALUE, exec("return 9223372036854775807L * 9223372036854775807L;"));
+        try {
+            exec("return 2147483647 * 2147483647;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("return 9223372036854775807L * 9223372036854775807L;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
     }
 }

--- a/src/test/java/org/elasticsearch/plan/a/SubtractionTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/SubtractionTests.java
@@ -178,12 +178,26 @@ public class SubtractionTests extends ScriptTestCase {
     }
   
     public void testOverflow() throws Exception {
-        assertEquals(-10 - Integer.MAX_VALUE, exec("int x = -10; int y = 2147483647; return x - y;"));
-        assertEquals(-10L - Long.MAX_VALUE, exec("long x = -10L; long y = 9223372036854775807L; return x - y;"));
+        try {
+            exec("int x = -10; int y = 2147483647; return x - y;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("long x = -10L; long y = 9223372036854775807L; return x - y;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
     }
     
     public void testOverflowConst() throws Exception {
-        assertEquals(-10 - Integer.MAX_VALUE, exec("return -10 - 2147483647;"));
-        assertEquals(-10L - Long.MAX_VALUE, exec("return -10L - 9223372036854775807L;"));
+        try {
+            exec("return -10 - 2147483647;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("return -10L - 9223372036854775807L;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
     }
 }

--- a/src/test/java/org/elasticsearch/plan/a/UnaryTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/UnaryTests.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plan.a;
+
+/** Tests for unary operators across different types */
+public class UnaryTests extends ScriptTestCase {
+
+    /** incrementing byte values */
+    public void testIncrementByte() {
+        assertEquals((byte)0, exec("byte x = (byte)0; return x++;"));
+        assertEquals((byte)0, exec("byte x = (byte)0; return x--;"));
+        assertEquals((byte)1, exec("byte x = (byte)0; return ++x;"));
+        assertEquals((byte)-1, exec("byte x = (byte)0; return --x;"));
+    }
+    
+    /** incrementing short values */
+    public void testIncrementShort() {
+        assertEquals((short)0, exec("short x = (short)0; return x++;"));
+        assertEquals((short)0, exec("short x = (short)0; return x--;"));
+        assertEquals((short)1, exec("short x = (short)0; return ++x;"));
+        assertEquals((short)-1, exec("short x = (short)0; return --x;"));
+    }
+
+    /** incrementing integer values */
+    public void testIncrementInt() {
+        assertEquals(0, exec("int x = 0; return x++;"));
+        assertEquals(0, exec("int x = 0; return x--;"));
+        assertEquals(1, exec("int x = 0; return ++x;"));
+        assertEquals(-1, exec("int x = 0; return --x;"));
+    }
+    
+    /** incrementing long values */
+    public void testIncrementLong() {
+        assertEquals(0L, exec("long x = 0; return x++;"));
+        assertEquals(0L, exec("long x = 0; return x--;"));
+        assertEquals(1L, exec("long x = 0; return ++x;"));
+        assertEquals(-1L, exec("long x = 0; return --x;"));
+    }
+    
+    /** incrementing float values */
+    public void testIncrementFloat() {
+        assertEquals(0F, exec("float x = 0F; return x++;"));
+        assertEquals(0F, exec("float x = 0F; return x--;"));
+        assertEquals(1F, exec("float x = 0F; return ++x;"));
+        assertEquals(-1F, exec("float x = 0F; return --x;"));
+    }
+    
+    /** incrementing double values */
+    public void testIncrementDouble() {
+        assertEquals(0D, exec("double x = 0.0; return x++;"));
+        assertEquals(0D, exec("double x = 0.0; return x--;"));
+        assertEquals(1D, exec("double x = 0.0; return ++x;"));
+        assertEquals(-1D, exec("double x = 0.0; return --x;"));
+    }
+
+    public void testUnary() {
+        assertEquals(false, exec("return !true;"));
+        assertEquals(true, exec("bool x = false; return !x;"));
+        assertEquals(-2, exec("return ~1;"));
+        assertEquals(-2, exec("byte x = 1; return ~x;"));
+        assertEquals(1, exec("return +1;"));
+        assertEquals(1.0, exec("double x = 1; return +x;"));
+        assertEquals(-1, exec("return -1;"));
+        assertEquals(-2, exec("short x = 2; return -x;"));
+    }
+
+    public void testNegationInt() throws Exception {
+        assertEquals(-1, exec("return -1;"));
+        assertEquals(1, exec("return -(-1);"));
+        assertEquals(0, exec("return -0;"));
+    }
+}


### PR DESCRIPTION
Throw ArithmeticException: integer overflow on overflows from add/sub/mul/div

These checks are either simple (div case) or supported by hardware, checking the overflow in flags. It is an easy win to prevent surprises.

I will do unary operations as a followup (negation, increment, decrement), and also look into float/double.