### PR TITLE
Remove int overflow / refactor compound assignment

### DIFF
--- a/src/main/java/org/elasticsearch/plan/a/External.java
+++ b/src/main/java/org/elasticsearch/plan/a/External.java
@@ -268,19 +268,20 @@ class External {
     }
 
     private class TokenSegment extends Segment {
-        private final Type type;
+        private final Type originalType;
+        private final Type promotedType;
         private final int token;
 
-        TokenSegment(final ParserRuleContext source, final Type type, final int token) {
+        TokenSegment(ParserRuleContext source, Type originalType, Type promotedType, int token) {
             super(source);
-
-            this.type = type;
+            this.originalType = originalType;
+            this.promotedType = promotedType;
             this.token = token;
         }
 
         @Override
         void write() {
-            writer.writeCompoundAssignmentInstruction(source, type.metadata, token);
+            writer.writeCompoundAssignmentInstruction(source, originalType.metadata, promotedType.metadata, token);
         }
     }
 
@@ -697,7 +698,7 @@ class External {
                 
                 segments.add(new CastSegment(source, casts[0]));
                 segments.add(new NodeSegment(write));
-                segments.add(new TokenSegment(source, current, token));
+                segments.add(new TokenSegment(source, variable.type, current, token));
                 segments.add(new CastSegment(source, casts[1]));
                 
                 if (read && !post) {
@@ -815,7 +816,7 @@ class External {
 
                     segments.add(new CastSegment(source, casts[0]));
                     segments.add(new NodeSegment(write));
-                    segments.add(new TokenSegment(source, current, token));
+                    segments.add(new TokenSegment(source, field.type, current, token));
                     segments.add(new CastSegment(source, casts[1]));
 
                     if (read && !post) {
@@ -1009,7 +1010,7 @@ class External {
 
                 segments.add(new CastSegment(source, casts[0]));
                 segments.add(new NodeSegment(write));
-                segments.add(new TokenSegment(source, current, token));
+                segments.add(new TokenSegment(source, type, current, token));
                 segments.add(new CastSegment(source, casts[1]));
 
                 if (read && !post) {

--- a/src/main/java/org/elasticsearch/plan/a/External.java
+++ b/src/main/java/org/elasticsearch/plan/a/External.java
@@ -280,7 +280,7 @@ class External {
 
         @Override
         void write() {
-            writer.writeIncrementInstruction(source, type.metadata, token);
+            writer.writeCompoundAssignmentInstruction(source, type.metadata, token);
         }
     }
 

--- a/src/main/java/org/elasticsearch/plan/a/Writer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Writer.java
@@ -1178,8 +1178,12 @@ class Writer extends PlanABaseVisitor<Void> {
         execute.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/StringBuilder", "toString", "()Ljava/lang/String;", false);
     }
     
-    void writeIncrementInstruction(final ParserRuleContext source, final TypeMetadata metadata, final int token) {
-        assert token == ADD; // today always an add: fix this
+    /**
+     * Called for any compound assignment (including increment/decrement instructions).
+     * We have to be stricter than writeBinary, and do overflow checks against the original type's size
+     * instead of the promoted type's size, since the result will be implicitly cast back.
+     */
+    void writeCompoundAssignmentInstruction(final ParserRuleContext source, final TypeMetadata metadata, final int token) {
         writeBinaryInstruction(source, metadata, token);
     }
     

--- a/src/main/java/org/elasticsearch/plan/a/Writer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Writer.java
@@ -1183,8 +1183,27 @@ class Writer extends PlanABaseVisitor<Void> {
      * We have to be stricter than writeBinary, and do overflow checks against the original type's size
      * instead of the promoted type's size, since the result will be implicitly cast back.
      */
-    void writeCompoundAssignmentInstruction(final ParserRuleContext source, final TypeMetadata metadata, final int token) {
-        writeBinaryInstruction(source, metadata, token);
+    void writeCompoundAssignmentInstruction(ParserRuleContext source, TypeMetadata original, TypeMetadata promoted, int token) {
+        switch (original) {
+            // these need special logic as they are implicitly promoted and
+            // then cast back during compound assignment.
+            case BYTE:
+            case SHORT:
+            case CHAR:
+                // TODO: special logic goes here
+                writeBinaryInstruction(source, promoted, token);
+                break;
+            // these types are never implicitly promoted during compound assignment
+            case INT:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+                assert original == promoted;
+                writeBinaryInstruction(source, promoted, token);
+                break;
+            default:
+                throw new IllegalStateException(error(source) + "Unexpected writer state.");
+        }
     }
     
     void writeBinaryInstruction(final ParserRuleContext source, final TypeMetadata metadata, final int token) {

--- a/src/main/java/org/elasticsearch/plan/a/Writer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Writer.java
@@ -1190,6 +1190,11 @@ class Writer extends PlanABaseVisitor<Void> {
         execute.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/StringBuilder", "toString", "()Ljava/lang/String;", false);
     }
     
+    void writeIncrementInstruction(final ParserRuleContext source, final TypeMetadata metadata, final int token) {
+        assert token == ADD; // today always an add: fix this
+        writeBinaryInstruction(source, metadata, token);
+    }
+    
     void writeBinaryInstruction(final ParserRuleContext source, final TypeMetadata metadata, final int token) {
         switch (metadata) {
             case INT:

--- a/src/test/java/org/elasticsearch/plan/a/IncrementTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/IncrementTests.java
@@ -98,10 +98,25 @@ public class IncrementTests extends ScriptTestCase {
         assertEquals(Character.MAX_VALUE, exec("char x = (char) 0; x--; return x;"));
         
         // int
-        assertEquals(Integer.MIN_VALUE, exec("int x = 2147483647; ++x; return x;"));
-        assertEquals(Integer.MIN_VALUE, exec("int x = 2147483647; x++; return x;"));
-        assertEquals(Integer.MAX_VALUE, exec("int x = (int) -2147483648L; --x; return x;"));
-        assertEquals(Integer.MAX_VALUE, exec("int x = (int) -2147483648L; x--; return x;"));
+        try {
+            exec("int x = 2147483647; ++x; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("int x = 2147483647; x++; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("int x = (int) -2147483648L; --x; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("int x = (int) -2147483648L; x--; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
         
         // long
         try {


### PR DESCRIPTION
For compound assignments (`+=`, `*=`, etc) as well as increments and decrements, overflow checks need to be consistent across all data types.

This adds them for `int` data types too (removes special IINC handling). We also refactor this stuff to make it easier to do proper checks for byte, short, and char which need some implementations and tests, coming in future PR :)