### PR TITLE
Fixed boolean operator for &= , |=, and ^=.

### DIFF
--- a/src/main/java/org/elasticsearch/plan/a/Analyzer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Analyzer.java
@@ -803,6 +803,8 @@ class Analyzer extends PlanABaseVisitor<Void> {
 
         if (ctx.ADD() != null || ctx.SUB() != null || ctx.DIV() != null || ctx.MUL() != null || ctx.REM() != null) {
             promotion = caster.decimal;
+        } else if (ctx.BWXOR() != null) {
+            promotion = caster.binary;
         } else {
             promotion = caster.numeric;
         }
@@ -920,7 +922,9 @@ class Analyzer extends PlanABaseVisitor<Void> {
                     throw new IllegalStateException(error(ctx) + "Unexpected parser state.");
                 }
             } else if (ctx.BWXOR() != null) {
-                if (tmd == TypeMetadata.INT) {
+                if (tmd == TypeMetadata.BOOL) {
+                    binaryemd.preConst = (boolean)expremd0.postConst ^ (boolean)expremd1.postConst;
+                } else if (tmd == TypeMetadata.INT) {
                     binaryemd.preConst = (int)expremd0.postConst ^ (int)expremd1.postConst;
                 } else if (tmd == TypeMetadata.LONG) {
                     binaryemd.preConst = (long)expremd0.postConst ^ (long)expremd1.postConst;

--- a/src/main/java/org/elasticsearch/plan/a/Caster.java
+++ b/src/main/java/org/elasticsearch/plan/a/Caster.java
@@ -255,6 +255,7 @@ class Caster {
     private final Definition definition;
     private final Standard standard;
 
+    final Promotion binary;
     final Promotion concat;
     final Promotion equality;
     final Promotion decimal;
@@ -266,6 +267,11 @@ class Caster {
         this.standard = standard;
 
         List<Segment> segments = new ArrayList<>();
+        segments.add(new AnyTypeSegment(this, standard.boolType));
+        segments.add(new AnyNumericSegment(this, false));
+        binary = new Promotion(segments);
+
+        segments = new ArrayList<>();
         segments.add(new SameTypeSegment());
         segments.add(new AnyTypeSegment(this, standard.boolType));
         segments.add(new AnyNumericSegment(this, true));

--- a/src/main/java/org/elasticsearch/plan/a/Writer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Writer.java
@@ -659,7 +659,11 @@ class Writer extends PlanABaseVisitor<Void> {
             visit(expr0);
             visit(expr1);
 
-            final TypeMetadata metadata = binaryemd.from.metadata;
+            // Promote any boolean metadata to int metadata for the
+            // purpose of writing binary instructions.
+
+            final TypeMetadata metadata = binaryemd.from.metadata == TypeMetadata.BOOL ?
+                    TypeMetadata.INT : binaryemd.from.metadata;
 
             if      (ctx.MUL()   != null) writeBinaryInstruction(ctx, metadata, MUL);
             else if (ctx.DIV()   != null) writeBinaryInstruction(ctx, metadata, DIV);
@@ -1218,7 +1222,7 @@ class Writer extends PlanABaseVisitor<Void> {
                 execute.visitInsn(Opcodes.L2I);
             }
         }
-        
+
         switch (metadata) {
             case INT:
                 switch (token) {

--- a/src/test/java/org/elasticsearch/plan/a/CompoundAssignmentTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/CompoundAssignmentTests.java
@@ -190,13 +190,24 @@ public class CompoundAssignmentTests extends ScriptTestCase {
         assertEquals(15L, exec("long x = 60L; x >>>= 2; return x;"));
         assertEquals(-60L >>> 2, exec("long x = -60L; x >>>= 2; return x;"));
     }
-    
-    @AwaitsFix(bugUrl = "buggy: boolean supports &=,|=,^=")
+
     public void testAnd() {
         // boolean
         assertEquals(true, exec("boolean x = true; x &= true; return x;"));
         assertEquals(false, exec("boolean x = true; x &= false; return x;"));
         assertEquals(false, exec("boolean x = false; x &= true; return x;"));
         assertEquals(false, exec("boolean x = false; x &= false; return x;"));
+        assertEquals(true, exec("Boolean x = true; x &= true; return x;"));
+        assertEquals(false, exec("Boolean x = true; x &= false; return x;"));
+        assertEquals(false, exec("Boolean x = false; x &= true; return x;"));
+        assertEquals(false, exec("Boolean x = false; x &= false; return x;"));
+        assertEquals(true, exec("boolean[] x = boolean.makearray(1); x[0] = true; x[0] &= true; return x[0];"));
+        assertEquals(false, exec("boolean[] x = boolean.makearray(1); x[0] = true; x[0] &= false; return x[0];"));
+        assertEquals(false, exec("boolean[] x = boolean.makearray(1); x[0] = false; x[0] &= true; return x[0];"));
+        assertEquals(false, exec("boolean[] x = boolean.makearray(1); x[0] = false; x[0] &= false; return x[0];"));
+        assertEquals(true, exec("Boolean[] x = Boolean.makearray(1); x[0] = true; x[0] &= true; return x[0];"));
+        assertEquals(false, exec("Boolean[] x = Boolean.makearray(1); x[0] = true; x[0] &= false; return x[0];"));
+        assertEquals(false, exec("Boolean[] x = Boolean.makearray(1); x[0] = false; x[0] &= true; return x[0];"));
+        assertEquals(false, exec("Boolean[] x = Boolean.makearray(1); x[0] = false; x[0] &= false; return x[0];"));
     }
 }

--- a/src/test/java/org/elasticsearch/plan/a/XorTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/XorTests.java
@@ -45,4 +45,18 @@ public class XorTests extends ScriptTestCase {
         assertEquals(5L ^ -12L, exec("return 5L ^ -12L;"));
         assertEquals(7L ^ 15L ^ 3L, exec("return 7L ^ 15L ^ 3L;"));
     }
+
+    public void testBool() throws Exception {
+        assertEquals(false, exec("boolean x = true; boolean y = true; return x ^ y;"));
+        assertEquals(true, exec("boolean x = true; boolean y = false; return x ^ y;"));
+        assertEquals(true, exec("boolean x = false; boolean y = true; return x ^ y;"));
+        assertEquals(false, exec("boolean x = false; boolean y = false; return x ^ y;"));
+    }
+
+    public void testBoolConst() throws Exception {
+        assertEquals(false, exec("return true ^ true;"));
+        assertEquals(true, exec("return true ^ false;"));
+        assertEquals(true, exec("return false ^ true;"));
+        assertEquals(false, exec("return false ^ false;"));
+    }
 }


### PR DESCRIPTION
Added code to be able to handle boolean operators correctly for xor (^) and the compound operators &= |= and ^=.