### PR TITLE
Don't allow overflow for compound assignment/increment/decrement of byte/char/short

### DIFF
--- a/src/main/java/org/elasticsearch/plan/a/Utility.java
+++ b/src/main/java/org/elasticsearch/plan/a/Utility.java
@@ -220,7 +220,45 @@ public class Utility {
             throw new ArithmeticException("long overflow");
         }
         return x / y;
-     }
+    }
+
+    // byte, short, and char are promoted to int for normal operations,
+    // so the JDK exact methods are typically used, and the result has a wider range.
+    // but compound assignments and increment/decrement operators (e.g. byte b = Byte.MAX_VALUE; b++;)
+    // implicitly cast back to the original type: so these need to be checked against the original range.
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for byte range.
+     */
+    public static byte toByteExact(int value) {
+        byte b = (byte) value;
+        if (b != value) {
+            throw new ArithmeticException("byte overflow");
+        }
+        return b;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for char range.
+     */
+    public static char toCharExact(int value) {
+        char c = (char) value;
+        if (c != value) {
+            throw new ArithmeticException("char overflow");
+        }
+        return c;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for short range.
+     */
+    public static short toShortExact(int value) {
+        short s = (short) value;
+        if (s != value) {
+            throw new ArithmeticException("short overflow");
+        }
+        return s;
+    }
 
     private Utility() {}
 }

--- a/src/main/java/org/elasticsearch/plan/a/Writer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Writer.java
@@ -1184,25 +1184,18 @@ class Writer extends PlanABaseVisitor<Void> {
      * instead of the promoted type's size, since the result will be implicitly cast back.
      */
     void writeCompoundAssignmentInstruction(ParserRuleContext source, TypeMetadata original, TypeMetadata promoted, int token) {
-        switch (original) {
-            // these need special logic as they are implicitly promoted and
-            // then cast back during compound assignment.
-            case BYTE:
-            case SHORT:
-            case CHAR:
-                // TODO: special logic goes here
-                writeBinaryInstruction(source, promoted, token);
-                break;
-            // these types are never implicitly promoted during compound assignment
-            case INT:
-            case LONG:
-            case FLOAT:
-            case DOUBLE:
+        writeBinaryInstruction(source, promoted, token);
+        if (token == ADD || token == SUB || token == MUL || token == DIV) {
+            if (original == TypeMetadata.BYTE) {
+                execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "toByteExact", "(I)B", false);
+            } else if (original == TypeMetadata.SHORT) {
+                execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "toShortExact", "(I)S", false);
+            } else if (original == TypeMetadata.CHAR) {
+                execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "toCharExact", "(I)C", false);
+            } else {
+                // all other types are never promoted during compound assignment
                 assert original == promoted;
-                writeBinaryInstruction(source, promoted, token);
-                break;
-            default:
-                throw new IllegalStateException(error(source) + "Unexpected writer state.");
+            }
         }
     }
     

--- a/src/test/java/org/elasticsearch/plan/a/CompoundAssignmentTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/CompoundAssignmentTests.java
@@ -27,6 +27,7 @@ public class CompoundAssignmentTests extends ScriptTestCase {
         // byte
         assertEquals((byte) 15, exec("byte x = 5; x += 10; return x;"));
         assertEquals((byte) -5, exec("byte x = 5; x += -10; return x;"));
+
         // short
         assertEquals((short) 15, exec("short x = 5; x += 10; return x;"));
         assertEquals((short) -5, exec("short x = 5; x += -10; return x;"));
@@ -45,6 +46,63 @@ public class CompoundAssignmentTests extends ScriptTestCase {
         // double
         assertEquals(15D, exec("double x = 5.0; x += 10; return x;"));
         assertEquals(-5D, exec("double x = 5.0; x += -10; return x;"));
+    }
+    
+    public void testAdditionOverflow() {
+        // byte
+        try {
+            exec("byte x = 0; x += 128; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("byte x = 0; x += -129; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // short
+        try {
+            exec("short x = 0; x += 32768; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("byte x = 0; x += -32769; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // char
+        try {
+            exec("char x = 0; x += 65536; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("char x = 0; x += -65536; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // int
+        try {
+            exec("int x = 1; x += 2147483647; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("int x = -2; x += -2147483647; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // long
+        try {
+            exec("long x = 1; x += 9223372036854775807L; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("long x = -2; x += -9223372036854775807L; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
     }
     
     public void testSubtraction() {
@@ -71,6 +129,63 @@ public class CompoundAssignmentTests extends ScriptTestCase {
         assertEquals(-5D, exec("double x = 5.0; x -= 10; return x;"));
     }
     
+    public void testSubtractionOverflow() {
+        // byte
+        try {
+            exec("byte x = 0; x -= -128; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("byte x = 0; x -= 129; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // short
+        try {
+            exec("short x = 0; x -= -32768; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("byte x = 0; x -= 32769; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // char
+        try {
+            exec("char x = 0; x -= -65536; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("char x = 0; x -= 65536; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // int
+        try {
+            exec("int x = 1; x -= -2147483647; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("int x = -2; x -= 2147483647; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // long
+        try {
+            exec("long x = 1; x -= -9223372036854775807L; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("long x = -2; x -= 9223372036854775807L; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
     public void testMultiplication() {
         // byte
         assertEquals((byte) 15, exec("byte x = 5; x *= 3; return x;"));
@@ -94,6 +209,52 @@ public class CompoundAssignmentTests extends ScriptTestCase {
         assertEquals(-5D, exec("double x = 5.0; x *= -1; return x;"));
     }
     
+    public void testMultiplicationOverflow() {
+        // byte
+        try {
+            exec("byte x = 2; x *= 128; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("byte x = 2; x *= -128; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // char
+        try {
+            exec("char x = 2; x *= 65536; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("char x = 2; x *= -65536; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // int
+        try {
+            exec("int x = 2; x *= 2147483647; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("int x = 2; x *= -2147483647; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // long
+        try {
+            exec("long x = 2; x *= 9223372036854775807L; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+
+        try {
+            exec("long x = 2; x *= -9223372036854775807L; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
     public void testDivision() {
         // byte
         assertEquals((byte) 15, exec("byte x = 45; x /= 3; return x;"));
@@ -115,6 +276,66 @@ public class CompoundAssignmentTests extends ScriptTestCase {
         // double
         assertEquals(15D, exec("double x = 45.0; x /= 3; return x;"));
         assertEquals(-5D, exec("double x = 5.0; x /= -1; return x;"));
+    }
+    
+    public void testDivisionOverflow() {
+        // byte
+        try {
+            exec("byte x = (byte) -128; x /= -1; return x;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+
+        // short
+        try {
+            exec("short x = (short) -32768; x /= -1; return x;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+        
+        // cannot happen for char: unsigned
+        
+        // int
+        try {
+            exec("int x = -2147483647 - 1; x /= -1; return x;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+        
+        // long
+        try {
+            exec("long x = -9223372036854775807L - 1L; x /=-1L; return x;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testDivisionByZero() {
+        // byte
+        try {
+            exec("byte x = 1; x /= 0; return x;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+
+        // short
+        try {
+            exec("short x = 1; x /= 0; return x;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+        
+        // char
+        try {
+            exec("char x = 1; x /= 0; return x;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+        
+        // int
+        try {
+            exec("int x = 1; x /= 0; return x;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
+        
+        // long
+        try {
+            exec("long x = 1; x /= 0; return x;");
+            fail("should have hit exception");
+        } catch (ArithmeticException expected) {}
     }
     
     public void testRemainder() {

--- a/src/test/java/org/elasticsearch/plan/a/DivisionTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/DivisionTests.java
@@ -152,7 +152,7 @@ public class DivisionTests extends ScriptTestCase {
         } catch (ArithmeticException expected) {}
         
         try {
-            System.out.println(exec("long x = -9223372036854775807L - 1L; long y = -1L; return x / y;"));
+            exec("long x = -9223372036854775807L - 1L; long y = -1L; return x / y;");
             fail("should have hit exception");
         } catch (ArithmeticException expected) {}
     }

--- a/src/test/java/org/elasticsearch/plan/a/IncrementTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/IncrementTests.java
@@ -33,9 +33,8 @@ public class IncrementTests extends ScriptTestCase {
     /** incrementing char values */
     public void testIncrementChar() {
         assertEquals((char)0, exec("char x = (char)0; return x++;"));
-        assertEquals((char)0, exec("char x = (char)0; return x--;"));
+        assertEquals((char)1, exec("char x = (char)1; return x--;"));
         assertEquals((char)1, exec("char x = (char)0; return ++x;"));
-        assertEquals((char)-1, exec("char x = (char)0; return --x;"));
     }
     
     /** incrementing short values */
@@ -80,22 +79,62 @@ public class IncrementTests extends ScriptTestCase {
     
     public void testIncOverFlow() throws Exception {
         // byte
-        assertEquals(Byte.MIN_VALUE, exec("byte x = 127; ++x; return x;"));
-        assertEquals(Byte.MIN_VALUE, exec("byte x = 127; x++; return x;"));
-        assertEquals(Byte.MAX_VALUE, exec("byte x = (byte) -128; --x; return x;"));
-        assertEquals(Byte.MAX_VALUE, exec("byte x = (byte) -128; x--; return x;"));
+        try {
+            exec("byte x = 127; ++x; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("byte x = 127; x++; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("byte x = (byte) -128; --x; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("byte x = (byte) -128; x--; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
         
         // short
-        assertEquals(Short.MIN_VALUE, exec("short x = 32767; ++x; return x;"));
-        assertEquals(Short.MIN_VALUE, exec("short x = 32767; x++; return x;"));
-        assertEquals(Short.MAX_VALUE, exec("short x = (short) -32768; --x; return x;"));
-        assertEquals(Short.MAX_VALUE, exec("short x = (short) -32768; x--; return x;"));
+        try {
+            exec("short x = 32767; ++x; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("short x = 32767; x++; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("short x = (short) -32768; --x; return x;");
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("short x = (short) -32768; x--; return x;");
+        } catch (ArithmeticException expected) {}
         
         // char
-        assertEquals(Character.MIN_VALUE, exec("char x = 65535; ++x; return x;"));
-        assertEquals(Character.MIN_VALUE, exec("char x = 65535; x++; return x;"));
-        assertEquals(Character.MAX_VALUE, exec("char x = (char) 0; --x; return x;"));
-        assertEquals(Character.MAX_VALUE, exec("char x = (char) 0; x--; return x;"));
+        try {
+            exec("char x = 65535; ++x; return x;");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("char x = 65535; x++; return x;");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("char x = (char) 0; --x; return x;");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            exec("char x = (char) 0; x--; return x;");
+        } catch (ArithmeticException expected) {}
         
         // int
         try {

--- a/src/test/java/org/elasticsearch/plan/a/UtilityTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/UtilityTests.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plan.a;
+
+import org.elasticsearch.test.ESTestCase;
+
+/**
+ * Tests utility methods (typically built-ins)
+ */
+public class UtilityTests extends ESTestCase {
+    
+    public void testDivideWithoutOverflowInt() {
+        assertEquals(5 / 2, Utility.divideWithoutOverflow(5, 2));
+
+        try {
+            Utility.divideWithoutOverflow(Integer.MIN_VALUE, -1);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.divideWithoutOverflow(5, 0);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testDivideWithoutOverflowLong() {
+        assertEquals(5L / 2L, Utility.divideWithoutOverflow(5L, 2L));
+        
+        try {
+            Utility.divideWithoutOverflow(Long.MIN_VALUE, -1L);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.divideWithoutOverflow(5L, 0L);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testToByteExact() {
+        for (int b = Byte.MIN_VALUE; b < Byte.MAX_VALUE; b++) {
+            assertEquals((byte)b, Utility.toByteExact(b));
+        }
+        
+        try {
+            Utility.toByteExact(Byte.MIN_VALUE - 1);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.toByteExact(Byte.MAX_VALUE + 1);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testToShortExact() {
+        for (int s = Short.MIN_VALUE; s < Short.MAX_VALUE; s++) {
+            assertEquals((short)s, Utility.toShortExact(s));
+        }
+        
+        try {
+            Utility.toShortExact(Short.MIN_VALUE - 1);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.toShortExact(Short.MAX_VALUE + 1);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testToCharExact() {
+        for (int c = Character.MIN_VALUE; c < Character.MAX_VALUE; c++) {
+            assertEquals((char)c, Utility.toCharExact(c));
+        }
+        
+        try {
+            Utility.toCharExact(Character.MIN_VALUE - 1);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.toCharExact(Character.MAX_VALUE + 1);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+}


### PR DESCRIPTION
This leaves only negation to tackle, then integral overflow is banned completely :)