### PR TITLE
Float overflow

### DIFF
--- a/src/main/java/org/elasticsearch/plan/a/Analyzer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Analyzer.java
@@ -853,9 +853,17 @@ class Analyzer extends PlanABaseVisitor<Void> {
                         binaryemd.preConst = Math.multiplyExact((long)expremd0.postConst, (long)expremd1.postConst);
                     }
                 } else if (tmd == TypeMetadata.FLOAT) {
-                    binaryemd.preConst = (float)expremd0.postConst * (float)expremd1.postConst;
+                    if (settings.getNumericOverflow()) {
+                        binaryemd.preConst = (float)expremd0.postConst * (float)expremd1.postConst;
+                    } else {
+                        binaryemd.preConst = Utility.multiplyWithoutOverflow((float)expremd0.postConst, (float)expremd1.postConst);
+                    }
                 } else if (tmd == TypeMetadata.DOUBLE) {
-                    binaryemd.preConst = (double)expremd0.postConst * (double)expremd1.postConst;
+                    if (settings.getNumericOverflow()) {
+                        binaryemd.preConst = (double)expremd0.postConst * (double)expremd1.postConst;
+                    } else {
+                        binaryemd.preConst = Utility.multiplyWithoutOverflow((double)expremd0.postConst, (double)expremd1.postConst);
+                    }
                 } else {
                     throw new IllegalStateException(error(ctx) + "Unexpected parser state.");
                 }
@@ -873,9 +881,17 @@ class Analyzer extends PlanABaseVisitor<Void> {
                         binaryemd.preConst = Utility.divideWithoutOverflow((long)expremd0.postConst, (long)expremd1.postConst);
                     }
                 } else if (tmd == TypeMetadata.FLOAT) {
-                    binaryemd.preConst = (float)expremd0.postConst / (float)expremd1.postConst;
+                    if (settings.getNumericOverflow()) {
+                        binaryemd.preConst = (float)expremd0.postConst / (float)expremd1.postConst;
+                    } else {
+                        binaryemd.preConst = Utility.divideWithoutOverflow((float)expremd0.postConst, (float)expremd1.postConst);
+                    }
                 } else if (tmd == TypeMetadata.DOUBLE) {
-                    binaryemd.preConst = (double)expremd0.postConst / (double)expremd1.postConst;
+                    if (settings.getNumericOverflow()) {
+                        binaryemd.preConst = (double)expremd0.postConst / (double)expremd1.postConst;
+                    } else {
+                        binaryemd.preConst = Utility.divideWithoutOverflow((double)expremd0.postConst, (double)expremd1.postConst);
+                    }
                 } else {
                     throw new IllegalStateException(error(ctx) + "Unexpected parser state.");
                 }
@@ -885,9 +901,17 @@ class Analyzer extends PlanABaseVisitor<Void> {
                 } else if (tmd == TypeMetadata.LONG) {
                     binaryemd.preConst = (long)expremd0.postConst % (long)expremd1.postConst;
                 } else if (tmd == TypeMetadata.FLOAT) {
-                    binaryemd.preConst = (float)expremd0.postConst % (float)expremd1.postConst;
+                    if (settings.getNumericOverflow()) {
+                        binaryemd.preConst = (float)expremd0.postConst % (float)expremd1.postConst;
+                    } else {
+                        binaryemd.preConst = Utility.remainderWithoutOverflow((float)expremd0.postConst, (float)expremd1.postConst);
+                    }
                 } else if (tmd == TypeMetadata.DOUBLE) {
-                    binaryemd.preConst = (double)expremd0.postConst % (double)expremd1.postConst;
+                    if (settings.getNumericOverflow()) {
+                        binaryemd.preConst = (double)expremd0.postConst % (double)expremd1.postConst;
+                    } else {
+                        binaryemd.preConst = Utility.remainderWithoutOverflow((double)expremd0.postConst, (double)expremd1.postConst);
+                    }
                 } else {
                     throw new IllegalStateException(error(ctx) + "Unexpected parser state.");
                 }
@@ -905,9 +929,17 @@ class Analyzer extends PlanABaseVisitor<Void> {
                         binaryemd.preConst = Math.addExact((long)expremd0.postConst, (long)expremd1.postConst);
                     }
                 } else if (tmd == TypeMetadata.FLOAT) {
-                    binaryemd.preConst = (float)expremd0.postConst + (float)expremd1.postConst;
+                    if (settings.getNumericOverflow()) {
+                        binaryemd.preConst = (float)expremd0.postConst + (float)expremd1.postConst;
+                    } else {
+                        binaryemd.preConst = Utility.addWithoutOverflow((float)expremd0.postConst, (float)expremd1.postConst);
+                    }
                 } else if (tmd == TypeMetadata.DOUBLE) {
-                    binaryemd.preConst = (double)expremd0.postConst + (double)expremd1.postConst;
+                    if (settings.getNumericOverflow()) {
+                        binaryemd.preConst = (double)expremd0.postConst + (double)expremd1.postConst;
+                    } else {
+                        binaryemd.preConst = Utility.addWithoutOverflow((double)expremd0.postConst, (double)expremd1.postConst);
+                    }
                 } else {
                     throw new IllegalStateException(error(ctx) + "Unexpected parser state.");
                 }
@@ -925,9 +957,17 @@ class Analyzer extends PlanABaseVisitor<Void> {
                         binaryemd.preConst = Math.subtractExact((long)expremd0.postConst, (long)expremd1.postConst);
                     }
                 } else if (tmd == TypeMetadata.FLOAT) {
-                    binaryemd.preConst = (float)expremd0.postConst - (float)expremd1.postConst;
+                    if (settings.getNumericOverflow()) {
+                        binaryemd.preConst = (float)expremd0.postConst - (float)expremd1.postConst;
+                    } else {
+                        binaryemd.preConst = Utility.subtractWithoutOverflow((float)expremd0.postConst, (float)expremd1.postConst);
+                    }
                 } else if (tmd == TypeMetadata.DOUBLE) {
-                    binaryemd.preConst = (double)expremd0.postConst - (double)expremd1.postConst;
+                    if (settings.getNumericOverflow()) {
+                        binaryemd.preConst = (double)expremd0.postConst - (double)expremd1.postConst;
+                    } else {
+                        binaryemd.preConst = Utility.subtractWithoutOverflow((double)expremd0.postConst, (double)expremd1.postConst);
+                    }
                 } else {
                     throw new IllegalStateException(error(ctx) + "Unexpected parser state.");
                 }

--- a/src/main/java/org/elasticsearch/plan/a/Analyzer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Analyzer.java
@@ -734,13 +734,13 @@ class Analyzer extends PlanABaseVisitor<Void> {
                     }
                 } else if (ctx.SUB() != null) {
                     if (tmd == TypeMetadata.INT) {
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             unaryemd.preConst = -(int)expremd.postConst;
                         } else {
                             unaryemd.preConst = Math.negateExact((int)expremd.postConst);
                         }
                     } else if (tmd == TypeMetadata.LONG) {
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             unaryemd.preConst = -(long)expremd.postConst;
                         } else {
                             unaryemd.preConst = Math.negateExact((long)expremd.postConst);
@@ -841,13 +841,13 @@ class Analyzer extends PlanABaseVisitor<Void> {
             
             if (ctx.MUL() != null) {
                 if (tmd == TypeMetadata.INT) {
-                    if (settings.getIntegerOverflow()) {
+                    if (settings.getNumericOverflow()) {
                         binaryemd.preConst = (int)expremd0.postConst * (int)expremd1.postConst;
                     } else {
                         binaryemd.preConst = Math.multiplyExact((int)expremd0.postConst, (int)expremd1.postConst);
                     }
                 } else if (tmd == TypeMetadata.LONG) {
-                    if (settings.getIntegerOverflow()) {
+                    if (settings.getNumericOverflow()) {
                         binaryemd.preConst = (long)expremd0.postConst * (long)expremd1.postConst;
                     } else {
                         binaryemd.preConst = Math.multiplyExact((long)expremd0.postConst, (long)expremd1.postConst);
@@ -861,13 +861,13 @@ class Analyzer extends PlanABaseVisitor<Void> {
                 }
             } else if (ctx.DIV() != null) {
                 if (tmd == TypeMetadata.INT) {
-                    if (settings.getIntegerOverflow()) {
+                    if (settings.getNumericOverflow()) {
                         binaryemd.preConst = (int)expremd0.postConst / (int)expremd1.postConst;
                     } else {
                         binaryemd.preConst = Utility.divideWithoutOverflow((int)expremd0.postConst, (int)expremd1.postConst);
                     }
                 } else if (tmd == TypeMetadata.LONG) {
-                    if (settings.getIntegerOverflow()) {
+                    if (settings.getNumericOverflow()) {
                         binaryemd.preConst = (long)expremd0.postConst / (long)expremd1.postConst;
                     } else {
                         binaryemd.preConst = Utility.divideWithoutOverflow((long)expremd0.postConst, (long)expremd1.postConst);
@@ -893,13 +893,13 @@ class Analyzer extends PlanABaseVisitor<Void> {
                 }
             } else if (ctx.ADD() != null) {
                 if (tmd == TypeMetadata.INT) {
-                    if (settings.getIntegerOverflow()) {
+                    if (settings.getNumericOverflow()) {
                         binaryemd.preConst = (int)expremd0.postConst + (int)expremd1.postConst;
                     } else {
                         binaryemd.preConst = Math.addExact((int)expremd0.postConst, (int)expremd1.postConst);
                     }
                 } else if (tmd == TypeMetadata.LONG) {
-                    if (settings.getIntegerOverflow()) {
+                    if (settings.getNumericOverflow()) {
                         binaryemd.preConst = (long)expremd0.postConst + (long)expremd1.postConst;
                     } else {
                         binaryemd.preConst = Math.addExact((long)expremd0.postConst, (long)expremd1.postConst);
@@ -913,13 +913,13 @@ class Analyzer extends PlanABaseVisitor<Void> {
                 }
             } else if (ctx.SUB() != null) {
                 if (tmd == TypeMetadata.INT) {
-                    if (settings.getIntegerOverflow()) {
+                    if (settings.getNumericOverflow()) {
                         binaryemd.preConst = (int)expremd0.postConst - (int)expremd1.postConst;
                     } else {
                         binaryemd.preConst = Math.subtractExact((int)expremd0.postConst, (int)expremd1.postConst);
                     }
                 } else if (tmd == TypeMetadata.LONG) {
-                    if (settings.getIntegerOverflow()) {
+                    if (settings.getNumericOverflow()) {
                         binaryemd.preConst = (long)expremd0.postConst - (long)expremd1.postConst;
                     } else {
                         binaryemd.preConst = Math.subtractExact((long)expremd0.postConst, (long)expremd1.postConst);

--- a/src/main/java/org/elasticsearch/plan/a/CompilerSettings.java
+++ b/src/main/java/org/elasticsearch/plan/a/CompilerSettings.java
@@ -24,22 +24,26 @@ package org.elasticsearch.plan.a;
  */
 final class CompilerSettings {
 
-    private boolean integerOverflow = true;
+    private boolean numericOverflow = true;
 
     /**
-     * Returns {@code true} if integer operations should overflow, false
-     * if they should signal an exception
-     * @see #setIntegerOverflow
+     * Returns {@code true} if numeric operations should overflow, {@code false}
+     * if they should signal an exception.
+     * <p>
+     * If this value is {@code true} (default), then things behave like java:
+     * overflow for integer types can result in unexpected values / unexpected 
+     * signs, and overflow for floating point types can result in infinite or
+     * {@code NaN} values.
      */
-    public boolean getIntegerOverflow() {
-        return integerOverflow;
+    public boolean getNumericOverflow() {
+        return numericOverflow;
     }
 
     /**
-     * Set {@code true} for integers to overflow, false to deliver exceptions.
-     * @see #getIntegerOverflow
+     * Set {@code true} for numerics to overflow, false to deliver exceptions.
+     * @see #getNumericOverflow
      */
-    public void setIntegerOverflow(boolean allow) {
-        this.integerOverflow = allow;
+    public void setNumericOverflow(boolean allow) {
+        this.numericOverflow = allow;
     }
 }

--- a/src/main/java/org/elasticsearch/plan/a/PlanAScriptEngineService.java
+++ b/src/main/java/org/elasticsearch/plan/a/PlanAScriptEngineService.java
@@ -42,12 +42,12 @@ public class PlanAScriptEngineService extends AbstractComponent implements Scrip
     // TODO: this should really be per-script since scripts do so many different things?
     private static final CompilerSettings compilerSettings = new CompilerSettings();
     
-    public static final String INTEGER_OVERFLOW = "plan-a.integer_overflow";
+    public static final String NUMERIC_OVERFLOW = "plan-a.numeric_overflow";
 
     @Inject
     public PlanAScriptEngineService(Settings settings) {
         super(settings);
-        compilerSettings.setIntegerOverflow(settings.getAsBoolean(INTEGER_OVERFLOW, compilerSettings.getIntegerOverflow()));
+        compilerSettings.setNumericOverflow(settings.getAsBoolean(NUMERIC_OVERFLOW, compilerSettings.getNumericOverflow()));
     }
 
     @Override

--- a/src/main/java/org/elasticsearch/plan/a/Utility.java
+++ b/src/main/java/org/elasticsearch/plan/a/Utility.java
@@ -259,6 +259,140 @@ public class Utility {
         }
         return s;
     }
+    
+    /**
+     * Checks for overflow, result is infinite but operands are finite
+     * @throws ArithmeticException if overflow occurred
+     */
+    private static float checkInfFloat(float x, float y, float z) {
+        if (Float.isInfinite(z)) {
+            if (Float.isFinite(x) && Float.isFinite(y)) {
+                throw new ArithmeticException("float overflow");
+            }
+        }
+        return z;
+    }
+    
+    /**
+     * Checks for NaN, result is NaN but operands are finite
+     * @throws ArithmeticException if overflow occurred
+     */
+    private static float checkNaNFloat(float x, float y, float z) {
+        if (Float.isNaN(z)) {
+            if (Float.isFinite(x) && Float.isFinite(y)) {
+                throw new ArithmeticException("NaN");
+            }
+        }
+        return z;
+    }
+    
+    /**
+     * Checks for NaN, result is infinite but operands are finite
+     * @throws ArithmeticException if overflow occurred
+     */
+    private static double checkInfDouble(double x, double y, double z) {
+        if (Double.isInfinite(z)) {
+            if (Double.isFinite(x) && Double.isFinite(y)) {
+                throw new ArithmeticException("double overflow");
+            }
+        }
+        return z;
+    }
+    
+    /**
+     * Checks for NaN, result is NaN but operands are finite
+     * @throws ArithmeticException if overflow occurred
+     */
+    private static double checkNaNDouble(double x, double y, double z) {
+        if (Double.isNaN(z)) {
+            if (Double.isFinite(x) && Double.isFinite(y)) {
+                throw new ArithmeticException("NaN");
+            }
+        }
+        return z;
+    }
+    
+    /**
+     * Adds two floats but throws {@code ArithmeticException}
+     * if the result overflows.
+     */
+    public static float addWithoutOverflow(float x, float y) {
+        return checkInfFloat(x, y, x + y);
+    }
+    
+    /**
+     * Adds two doubles but throws {@code ArithmeticException}
+     * if the result overflows.
+     */
+    public static double addWithoutOverflow(double x, double y) {
+        return checkInfDouble(x, y, x + y);
+    }
+    
+    /**
+     * Subtracts two floats but throws {@code ArithmeticException}
+     * if the result overflows.
+     */
+    public static float subtractWithoutOverflow(float x, float y) {
+        return checkInfFloat(x, y, x - y);
+    }
+    
+    /**
+     * Subtracts two doubles but throws {@code ArithmeticException}
+     * if the result overflows.
+     */
+    public static double subtractWithoutOverflow(double x, double y) {
+        return checkInfDouble(x, y , x - y);
+    }
+    
+    /**
+     * Multiplies two floats but throws {@code ArithmeticException}
+     * if the result overflows.
+     */
+    public static float multiplyWithoutOverflow(float x, float y) {
+        return checkInfFloat(x, y, x * y);
+    }
+    
+    /**
+     * Multiplies two doubles but throws {@code ArithmeticException}
+     * if the result overflows.
+     */
+    public static double multiplyWithoutOverflow(double x, double y) {
+        return checkInfDouble(x, y, x * y);
+    }
+    
+    /**
+     * Divides two floats but throws {@code ArithmeticException}
+     * if the result overflows, or would create NaN from finite
+     * inputs ({@code x == 0, y == 0})
+     */
+    public static float divideWithoutOverflow(float x, float y) {
+        return checkNaNFloat(x, y, checkInfFloat(x, y, x / y));
+    }
+    
+    /**
+     * Divides two doubles but throws {@code ArithmeticException}
+     * if the result overflows, or would create NaN from finite
+     * inputs ({@code x == 0, y == 0})
+     */
+    public static double divideWithoutOverflow(double x, double y) {
+        return checkNaNDouble(x, y, checkInfDouble(x, y, x / y));
+    }
+    
+    /**
+     * Takes remainder two floats but throws {@code ArithmeticException}
+     * if the result would create NaN from finite inputs ({@code y == 0})
+     */
+    public static float remainderWithoutOverflow(float x, float y) {
+        return checkNaNFloat(x, y, x % y);
+    }
+    
+    /**
+     * Divides two doubles but throws {@code ArithmeticException}
+     * if the result would create NaN from finite inputs ({@code y == 0})
+     */
+    public static double remainderWithoutOverflow(double x, double y) {
+        return checkNaNDouble(x, y, x % y);
+    }
 
     private Utility() {}
 }

--- a/src/main/java/org/elasticsearch/plan/a/Writer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Writer.java
@@ -1328,11 +1328,41 @@ class Writer extends PlanABaseVisitor<Void> {
                 break;
             case FLOAT:
                 switch (token) {
-                    case MUL: execute.visitInsn(Opcodes.FMUL); break;
-                    case DIV: execute.visitInsn(Opcodes.FDIV); break;
-                    case REM: execute.visitInsn(Opcodes.FREM); break;
-                    case ADD: execute.visitInsn(Opcodes.FADD); break;
-                    case SUB: execute.visitInsn(Opcodes.FSUB); break;
+                    case MUL:
+                        if (settings.getNumericOverflow()) {
+                            execute.visitInsn(Opcodes.FMUL);
+                        } else {
+                            execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "multiplyWithoutOverflow", "(FF)F", false);
+                        }
+                        break;
+                    case DIV: 
+                        if (settings.getNumericOverflow()) {
+                            execute.visitInsn(Opcodes.FDIV);
+                        } else {
+                            execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "divideWithoutOverflow", "(FF)F", false);
+                        }
+                        break;
+                    case REM:
+                        if (settings.getNumericOverflow()) {
+                            execute.visitInsn(Opcodes.FREM);
+                        } else {
+                            execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "remainderWithoutOverflow", "(FF)F", false);
+                        }
+                        break;
+                    case ADD: 
+                        if (settings.getNumericOverflow()) {
+                            execute.visitInsn(Opcodes.FADD);
+                        } else {
+                            execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "addWithoutOverflow", "(FF)F", false);
+                        }
+                        break;
+                    case SUB:
+                        if (settings.getNumericOverflow()) {
+                            execute.visitInsn(Opcodes.FSUB);
+                        } else {
+                            execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "subtractWithoutOverflow", "(FF)F", false);
+                        }
+                        break;
                     default:
                         throw new IllegalStateException(error(source) + "Unexpected writer state.");
                 }
@@ -1340,11 +1370,41 @@ class Writer extends PlanABaseVisitor<Void> {
                 break;
             case DOUBLE:
                 switch (token) {
-                    case MUL: execute.visitInsn(Opcodes.DMUL); break;
-                    case DIV: execute.visitInsn(Opcodes.DDIV); break;
-                    case REM: execute.visitInsn(Opcodes.DREM); break;
-                    case ADD: execute.visitInsn(Opcodes.DADD); break;
-                    case SUB: execute.visitInsn(Opcodes.DSUB); break;
+                    case MUL:
+                        if (settings.getNumericOverflow()) {
+                            execute.visitInsn(Opcodes.DMUL);
+                        } else {
+                            execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "multiplyWithoutOverflow", "(DD)D", false);
+                        }
+                        break;
+                    case DIV: 
+                        if (settings.getNumericOverflow()) {
+                            execute.visitInsn(Opcodes.DDIV);
+                        } else {
+                            execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "divideWithoutOverflow", "(DD)D", false);
+                        }
+                        break;
+                    case REM:
+                        if (settings.getNumericOverflow()) {
+                            execute.visitInsn(Opcodes.DREM);
+                        } else {
+                            execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "remainderWithoutOverflow", "(DD)D", false);
+                        }
+                        break;
+                    case ADD: 
+                        if (settings.getNumericOverflow()) {
+                            execute.visitInsn(Opcodes.DADD);
+                        } else {
+                            execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "addWithoutOverflow", "(DD)D", false);
+                        }
+                        break;
+                    case SUB:
+                        if (settings.getNumericOverflow()) {
+                            execute.visitInsn(Opcodes.DSUB);
+                        } else {
+                            execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "subtractWithoutOverflow", "(DD)D", false);
+                        }
+                        break;
                     default:
                         throw new IllegalStateException(error(source) + "Unexpected writer state.");
                 }

--- a/src/main/java/org/elasticsearch/plan/a/Writer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Writer.java
@@ -607,13 +607,13 @@ class Writer extends PlanABaseVisitor<Void> {
                     }
                 } else if (ctx.SUB() != null) {
                     if (metadata == TypeMetadata.INT) {
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             execute.visitInsn(Opcodes.INEG);
                         } else {
                             execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "negateExact", "(I)I", false);
                         }
                     } else if (metadata == TypeMetadata.LONG) {
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             execute.visitInsn(Opcodes.LNEG);
                         } else {
                             execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "negateExact", "(J)J", false);
@@ -1212,7 +1212,7 @@ class Writer extends PlanABaseVisitor<Void> {
      */
     void writeCompoundAssignmentInstruction(ParserRuleContext source, TypeMetadata original, TypeMetadata promoted, int token) {
         writeBinaryInstruction(source, promoted, token);
-        if (settings.getIntegerOverflow() == false) {
+        if (settings.getNumericOverflow() == false) {
             if (token == ADD || token == SUB || token == MUL || token == DIV) {
                 if (original == TypeMetadata.BYTE) {
                     execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "toByteExact", "(I)B", false);
@@ -1245,28 +1245,28 @@ class Writer extends PlanABaseVisitor<Void> {
             case INT:
                 switch (token) {
                     case MUL:   
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             execute.visitInsn(Opcodes.IMUL);
                         } else {
                             execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "multiplyExact", "(II)I", false);
                         }
                         break;
                     case DIV:   
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             execute.visitInsn(Opcodes.IDIV);
                         } else {
                             execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "divideWithoutOverflow", "(II)I", false);
                         }
                         break;
                     case ADD:   
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             execute.visitInsn(Opcodes.IADD);
                         } else {
                             execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "addExact", "(II)I", false);
                         }
                         break;
                     case SUB:   
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             execute.visitInsn(Opcodes.ISUB);
                         } else {
                             execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "subtractExact", "(II)I", false);
@@ -1287,28 +1287,28 @@ class Writer extends PlanABaseVisitor<Void> {
             case LONG:
                 switch (token) {
                     case MUL:
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             execute.visitInsn(Opcodes.LMUL);
                         } else {
                             execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "multiplyExact", "(JJ)J", false);
                         }
                         break;
                     case DIV:
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             execute.visitInsn(Opcodes.LDIV);
                         } else {
                             execute.visitMethodInsn(Opcodes.INVOKESTATIC, "org/elasticsearch/plan/a/Utility", "divideWithoutOverflow", "(JJ)J", false);
                         }
                         break;
                     case ADD:
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             execute.visitInsn(Opcodes.LADD);
                         } else {
                             execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "addExact", "(JJ)J", false);
                         }
                         break;
                     case SUB:
-                        if (settings.getIntegerOverflow()) {
+                        if (settings.getNumericOverflow()) {
                             execute.visitInsn(Opcodes.LSUB);
                         } else {
                             execute.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Math", "subtractExact", "(JJ)J", false);

--- a/src/test/java/org/elasticsearch/plan/a/FloatOverflowDisabledTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/FloatOverflowDisabledTests.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plan.a;
+
+import org.elasticsearch.common.settings.Settings;
+
+/** Tests floating point overflow with numeric overflow disabled */
+public class FloatOverflowDisabledTests extends ScriptTestCase {
+    
+    @Override
+    protected Settings getSettings() {
+        Settings.Builder builder = Settings.builder();
+        builder.put(super.getSettings());
+        builder.put(PlanAScriptEngineService.NUMERIC_OVERFLOW, false);
+        return builder.build();
+    }
+
+    public void testAssignmentAdditionOverflow() {        
+        // float
+        try {
+            exec("float x = 3.4028234663852886E38f; x += 3.4028234663852886E38f; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("float x = -3.4028234663852886E38f; x += -3.4028234663852886E38f; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // double
+        try {
+            exec("double x = 1.7976931348623157E308; x += 1.7976931348623157E308; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = -1.7976931348623157E308; x += -1.7976931348623157E308; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testAssignmentSubtractionOverflow() {    
+        // float
+        try {
+            exec("float x = 3.4028234663852886E38f; x -= -3.4028234663852886E38f; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("float x = -3.4028234663852886E38f; x -= 3.4028234663852886E38f; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // double
+        try {
+            exec("double x = 1.7976931348623157E308; x -= -1.7976931348623157E308; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = -1.7976931348623157E308; x -= 1.7976931348623157E308; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testAssignmentMultiplicationOverflow() {
+        // float
+        try {
+            exec("float x = 3.4028234663852886E38f; x *= 3.4028234663852886E38f; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("float x = 3.4028234663852886E38f; x *= -3.4028234663852886E38f; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // double
+        try {
+            exec("double x = 1.7976931348623157E308; x *= 1.7976931348623157E308; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = 1.7976931348623157E308; x *= -1.7976931348623157E308; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testAssignmentDivisionOverflow() {
+        // float
+        try {
+            exec("float x = 3.4028234663852886E38f; x /= 1.401298464324817E-45f; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("float x = 3.4028234663852886E38f; x /= -1.401298464324817E-45f; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("float x = 1.0f; x /= 0.0f; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // double
+        try {
+            exec("double x = 1.7976931348623157E308; x /= 4.9E-324; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = 1.7976931348623157E308; x /= -4.9E-324; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = 1.0f; x /= 0.0; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+
+    public void testAddition() throws Exception {
+        try {
+            exec("float x = 3.4028234663852886E38f; float y = 3.4028234663852886E38f; return x + y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = 1.7976931348623157E308; double y = 1.7976931348623157E308; return x + y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testAdditionConst() throws Exception {
+        try {
+            exec("return 3.4028234663852886E38f + 3.4028234663852886E38f;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("return 1.7976931348623157E308 + 1.7976931348623157E308;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testSubtraction() throws Exception {
+        try {
+            exec("float x = -3.4028234663852886E38f; float y = 3.4028234663852886E38f; return x - y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = -1.7976931348623157E308; double y = 1.7976931348623157E308; return x - y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testSubtractionConst() throws Exception {
+        try {
+            exec("return -3.4028234663852886E38f - 3.4028234663852886E38f;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("return -1.7976931348623157E308 - 1.7976931348623157E308;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testMultiplication() throws Exception {
+        try {
+            exec("float x = 3.4028234663852886E38f; float y = 3.4028234663852886E38f; return x * y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = 1.7976931348623157E308; double y = 1.7976931348623157E308; return x * y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testMultiplicationConst() throws Exception {
+        try {
+            exec("return 3.4028234663852886E38f * 3.4028234663852886E38f;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("return 1.7976931348623157E308 * 1.7976931348623157E308;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+
+    public void testDivision() throws Exception {
+        try {
+            exec("float x = 3.4028234663852886E38f; float y = 1.401298464324817E-45f; return x / y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("float x = 1.0f; float y = 0.0f; return x / y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = 1.7976931348623157E308; double y = 4.9E-324; return x / y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = 1.0; double y = 0.0; return x / y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testDivisionConst() throws Exception {
+        try {
+            exec("return 3.4028234663852886E38f / 1.401298464324817E-45f;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("return 1.0f / 0.0f;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("return 1.7976931348623157E308 / 4.9E-324;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("return 1.0 / 0.0;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testDivisionNaN() throws Exception {
+        // float division, constant division, and assignment
+        try {
+            exec("float x = 0f; float y = 0f; return x / y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("return 0f / 0f;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("float x = 0f; x /= 0f; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // double division, constant division, and assignment
+        try {
+            exec("double x = 0.0; double y = 0.0; return x / y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("return 0.0 / 0.0;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = 0.0; x /= 0.0; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testRemainderNaN() throws Exception {
+        // float division, constant division, and assignment
+        try {
+            exec("float x = 1f; float y = 0f; return x % y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("return 1f % 0f;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("float x = 1f; x %= 0f; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        // double division, constant division, and assignment
+        try {
+            exec("double x = 1.0; double y = 0.0; return x % y;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("return 1.0 % 0.0;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+        try {
+            exec("double x = 1.0; x %= 0.0; return x;");
+            fail("didn't hit expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+}

--- a/src/test/java/org/elasticsearch/plan/a/FloatOverflowEnabledTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/FloatOverflowEnabledTests.java
@@ -33,104 +33,112 @@ public class FloatOverflowEnabledTests extends ScriptTestCase {
     }
 
     public void testAssignmentAdditionOverflow() {        
-        // int
-        assertEquals(1 + 2147483647, exec("int x = 1; x += 2147483647; return x;"));
-        assertEquals(-2 + -2147483647, exec("int x = -2; x += -2147483647; return x;"));
+        // float
+        assertEquals(Float.POSITIVE_INFINITY, exec("float x = 3.4028234663852886E38f; x += 3.4028234663852886E38f; return x;"));
+        assertEquals(Float.NEGATIVE_INFINITY, exec("float x = -3.4028234663852886E38f; x += -3.4028234663852886E38f; return x;"));
         
-        // long
-        assertEquals(1L + 9223372036854775807L, exec("long x = 1; x += 9223372036854775807L; return x;"));
-        assertEquals(-2L + -9223372036854775807L, exec("long x = -2; x += -9223372036854775807L; return x;"));
+        // double
+        assertEquals(Double.POSITIVE_INFINITY, exec("double x = 1.7976931348623157E308; x += 1.7976931348623157E308; return x;"));
+        assertEquals(Double.NEGATIVE_INFINITY, exec("double x = -1.7976931348623157E308; x += -1.7976931348623157E308; return x;"));
     }
     
-    public void testAssignmentSubtractionOverflow() {        
-        // int
-        assertEquals(1 - -2147483647, exec("int x = 1; x -= -2147483647; return x;"));
-        assertEquals(-2 - 2147483647, exec("int x = -2; x -= 2147483647; return x;"));
+    public void testAssignmentSubtractionOverflow() {    
+        // float
+        assertEquals(Float.POSITIVE_INFINITY, exec("float x = 3.4028234663852886E38f; x -= -3.4028234663852886E38f; return x;"));
+        assertEquals(Float.NEGATIVE_INFINITY, exec("float x = -3.4028234663852886E38f; x -= 3.4028234663852886E38f; return x;"));
         
-        // long
-        assertEquals(1L - -9223372036854775807L, exec("long x = 1; x -= -9223372036854775807L; return x;"));
-        assertEquals(-2L - 9223372036854775807L, exec("long x = -2; x -= 9223372036854775807L; return x;"));
+        // double
+        assertEquals(Double.POSITIVE_INFINITY, exec("double x = 1.7976931348623157E308; x -= -1.7976931348623157E308; return x;"));
+        assertEquals(Double.NEGATIVE_INFINITY, exec("double x = -1.7976931348623157E308; x -= 1.7976931348623157E308; return x;"));
     }
     
     public void testAssignmentMultiplicationOverflow() {
-        // int
-        assertEquals(2 * 2147483647, exec("int x = 2; x *= 2147483647; return x;"));
-        assertEquals(2 * -2147483647, exec("int x = 2; x *= -2147483647; return x;"));
+        // float
+        assertEquals(Float.POSITIVE_INFINITY, exec("float x = 3.4028234663852886E38f; x *= 3.4028234663852886E38f; return x;"));
+        assertEquals(Float.NEGATIVE_INFINITY, exec("float x = 3.4028234663852886E38f; x *= -3.4028234663852886E38f; return x;"));
         
-        // long
-        assertEquals(2L * 9223372036854775807L, exec("long x = 2; x *= 9223372036854775807L; return x;"));
-        assertEquals(2L * -9223372036854775807L, exec("long x = 2; x *= -9223372036854775807L; return x;"));
+        // double
+        assertEquals(Double.POSITIVE_INFINITY, exec("double x = 1.7976931348623157E308; x *= 1.7976931348623157E308; return x;"));
+        assertEquals(Double.NEGATIVE_INFINITY, exec("double x = 1.7976931348623157E308; x *= -1.7976931348623157E308; return x;"));
     }
     
     public void testAssignmentDivisionOverflow() {
-        // int
-        assertEquals((-2147483647 - 1) / -1, exec("int x = -2147483647 - 1; x /= -1; return x;"));
+        // float
+        assertEquals(Float.POSITIVE_INFINITY, exec("float x = 3.4028234663852886E38f; x /= 1.401298464324817E-45f; return x;"));
+        assertEquals(Float.NEGATIVE_INFINITY, exec("float x = 3.4028234663852886E38f; x /= -1.401298464324817E-45f; return x;"));
+        assertEquals(Float.POSITIVE_INFINITY, exec("float x = 1.0f; x /= 0.0f; return x;"));
         
-        // long
-        assertEquals((-9223372036854775807L - 1L) / -1L, exec("long x = -9223372036854775807L - 1L; x /=-1L; return x;"));
+        // double
+        assertEquals(Double.POSITIVE_INFINITY, exec("double x = 1.7976931348623157E308; x /= 4.9E-324; return x;"));
+        assertEquals(Double.NEGATIVE_INFINITY, exec("double x = 1.7976931348623157E308; x /= -4.9E-324; return x;"));
+        assertEquals(Double.POSITIVE_INFINITY, exec("double x = 1.0f; x /= 0.0; return x;"));
     }
-    
-    public void testIncrementOverFlow() throws Exception {
-        // int
-        assertEquals(2147483647 + 1, exec("int x = 2147483647; ++x; return x;"));        
-        assertEquals(2147483647 + 1, exec("int x = 2147483647; x++; return x;"));
-        assertEquals(-2147483648 - 1, exec("int x = (int) -2147483648L; --x; return x;"));        
-        assertEquals(-2147483648 - 1, exec("int x = (int) -2147483648L; x--; return x;"));
-        
-        // long
-        assertEquals(9223372036854775807L + 1L, exec("long x = 9223372036854775807L; ++x; return x;"));        
-        assertEquals(9223372036854775807L + 1L, exec("long x = 9223372036854775807L; x++; return x;"));
-        assertEquals(-9223372036854775807L - 1L - 1L, exec("long x = -9223372036854775807L - 1L; --x; return x;"));
-        assertEquals(-9223372036854775807L - 1L - 1L, exec("long x = -9223372036854775807L - 1L; x--; return x;"));
-    }
-    
+
     public void testAddition() throws Exception {
-        assertEquals(2147483647 + 2147483647, exec("int x = 2147483647; int y = 2147483647; return x + y;"));        
-        assertEquals(9223372036854775807L + 9223372036854775807L, exec("long x = 9223372036854775807L; long y = 9223372036854775807L; return x + y;"));
+        assertEquals(Float.POSITIVE_INFINITY, exec("float x = 3.4028234663852886E38f; float y = 3.4028234663852886E38f; return x + y;"));        
+        assertEquals(Double.POSITIVE_INFINITY, exec("double x = 1.7976931348623157E308; double y = 1.7976931348623157E308; return x + y;"));
     }
     
     public void testAdditionConst() throws Exception {
-        assertEquals(2147483647 + 2147483647, exec("return 2147483647 + 2147483647;"));        
-        assertEquals(9223372036854775807L + 9223372036854775807L, exec("return 9223372036854775807L + 9223372036854775807L;"));
+        assertEquals(Float.POSITIVE_INFINITY, exec("return 3.4028234663852886E38f + 3.4028234663852886E38f;"));        
+        assertEquals(Double.POSITIVE_INFINITY, exec("return 1.7976931348623157E308 + 1.7976931348623157E308;"));
     }
     
     public void testSubtraction() throws Exception {
-        assertEquals(-10 - 2147483647, exec("int x = -10; int y = 2147483647; return x - y;"));        
-        assertEquals(-10L - 9223372036854775807L, exec("long x = -10L; long y = 9223372036854775807L; return x - y;"));
+        assertEquals(Float.NEGATIVE_INFINITY, exec("float x = -3.4028234663852886E38f; float y = 3.4028234663852886E38f; return x - y;"));        
+        assertEquals(Double.NEGATIVE_INFINITY, exec("double x = -1.7976931348623157E308; double y = 1.7976931348623157E308; return x - y;"));
     }
     
     public void testSubtractionConst() throws Exception {
-        assertEquals(-10 - 2147483647, exec("return -10 - 2147483647;"));        
-        assertEquals(-10L - 9223372036854775807L, exec("return -10L - 9223372036854775807L;"));
+        assertEquals(Float.NEGATIVE_INFINITY, exec("return -3.4028234663852886E38f - 3.4028234663852886E38f;"));        
+        assertEquals(Double.NEGATIVE_INFINITY, exec("return -1.7976931348623157E308 - 1.7976931348623157E308;"));
     }
     
     public void testMultiplication() throws Exception {
-        assertEquals(2147483647 * 2147483647, exec("int x = 2147483647; int y = 2147483647; return x * y;"));        
-        assertEquals(9223372036854775807L * 9223372036854775807L, exec("long x = 9223372036854775807L; long y = 9223372036854775807L; return x * y;"));
+        assertEquals(Float.POSITIVE_INFINITY, exec("float x = 3.4028234663852886E38f; float y = 3.4028234663852886E38f; return x * y;"));        
+        assertEquals(Double.POSITIVE_INFINITY, exec("double x = 1.7976931348623157E308; double y = 1.7976931348623157E308; return x * y;"));
     }
     
     public void testMultiplicationConst() throws Exception {
-        assertEquals(2147483647 * 2147483647, exec("return 2147483647 * 2147483647;"));
-        assertEquals(9223372036854775807L * 9223372036854775807L, exec("return 9223372036854775807L * 9223372036854775807L;"));
+        assertEquals(Float.POSITIVE_INFINITY, exec("return 3.4028234663852886E38f * 3.4028234663852886E38f;"));        
+        assertEquals(Double.POSITIVE_INFINITY, exec("return 1.7976931348623157E308 * 1.7976931348623157E308;"));
     }
 
     public void testDivision() throws Exception {
-        assertEquals((-2147483647 - 1) / -1, exec("int x = -2147483647 - 1; int y = -1; return x / y;"));        
-        assertEquals((-9223372036854775807L - 1L) / -1L, exec("long x = -9223372036854775807L - 1L; long y = -1L; return x / y;"));
+        assertEquals(Float.POSITIVE_INFINITY, exec("float x = 3.4028234663852886E38f; float y = 1.401298464324817E-45f; return x / y;"));
+        assertEquals(Float.POSITIVE_INFINITY, exec("float x = 1.0f; float y = 0.0f; return x / y;"));
+        assertEquals(Double.POSITIVE_INFINITY, exec("double x = 1.7976931348623157E308; double y = 4.9E-324; return x / y;"));
+        assertEquals(Double.POSITIVE_INFINITY, exec("double x = 1.0; double y = 0.0; return x / y;"));
     }
     
     public void testDivisionConst() throws Exception {
-        assertEquals((-2147483647 - 1) / -1, exec("return (-2147483647 - 1) / -1;"));
-        assertEquals((-9223372036854775807L - 1L) / -1L, exec("return (-9223372036854775807L - 1L) / -1L;"));
+        assertEquals(Float.POSITIVE_INFINITY, exec("return 3.4028234663852886E38f / 1.401298464324817E-45f;"));
+        assertEquals(Float.POSITIVE_INFINITY, exec("return 1.0f / 0.0f;"));
+        assertEquals(Double.POSITIVE_INFINITY, exec("return 1.7976931348623157E308 / 4.9E-324;"));
+        assertEquals(Double.POSITIVE_INFINITY, exec("return 1.0 / 0.0;"));
     }
     
-    public void testNegationOverflow() throws Exception {
-        assertEquals(-(-2147483647 - 1), exec("int x = -2147483647 - 1; x = -x; return x;"));        
-        assertEquals(-(-9223372036854775807L - 1L), exec("long x = -9223372036854775807L - 1L; x = -x; return x;"));
+    public void testDivisionNaN() throws Exception {
+        // float division, constant division, and assignment
+        assertTrue(Float.isNaN((Float) exec("float x = 0f; float y = 0f; return x / y;")));
+        assertTrue(Float.isNaN((Float) exec("return 0f / 0f;")));
+        assertTrue(Float.isNaN((Float) exec("float x = 0f; x /= 0f; return x;")));
+        
+        // double division, constant division, and assignment
+        assertTrue(Double.isNaN((Double) exec("double x = 0.0; double y = 0.0; return x / y;")));
+        assertTrue(Double.isNaN((Double) exec("return 0.0 / 0.0;")));
+        assertTrue(Double.isNaN((Double) exec("double x = 0.0; x /= 0.0; return x;")));
     }
     
-    public void testNegationOverflowConst() throws Exception {
-        assertEquals(-(-2147483647 - 1), exec("int x = -(-2147483647 - 1); return x;"));
-        assertEquals(-(-9223372036854775807L - 1L), exec("long x = -(-9223372036854775807L - 1L); return x;"));
+    public void testRemainderNaN() throws Exception {
+        // float division, constant division, and assignment
+        assertTrue(Float.isNaN((Float) exec("float x = 1f; float y = 0f; return x % y;")));
+        assertTrue(Float.isNaN((Float) exec("return 1f % 0f;")));
+        assertTrue(Float.isNaN((Float) exec("float x = 1f; x %= 0f; return x;")));
+        
+        // double division, constant division, and assignment
+        assertTrue(Double.isNaN((Double) exec("double x = 1.0; double y = 0.0; return x % y;")));
+        assertTrue(Double.isNaN((Double) exec("return 1.0 % 0.0;")));
+        assertTrue(Double.isNaN((Double) exec("double x = 1.0; x %= 0.0; return x;")));
     }
 }

--- a/src/test/java/org/elasticsearch/plan/a/FloatOverflowEnabledTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/FloatOverflowEnabledTests.java
@@ -21,8 +21,8 @@ package org.elasticsearch.plan.a;
 
 import org.elasticsearch.common.settings.Settings;
 
-/** Tests integer overflow with numeric overflow enabled */
-public class IntegerOverflowEnabledTests extends ScriptTestCase {
+/** Tests floating point overflow with numeric overflow enabled */
+public class FloatOverflowEnabledTests extends ScriptTestCase {
     
     @Override
     protected Settings getSettings() {
@@ -32,19 +32,7 @@ public class IntegerOverflowEnabledTests extends ScriptTestCase {
         return builder.build();
     }
 
-    public void testAssignmentAdditionOverflow() {
-        // byte
-        assertEquals((byte)(0 + 128), exec("byte x = 0; x += 128; return x;"));
-        assertEquals((byte)(0 + -129), exec("byte x = 0; x += -129; return x;"));
-        
-        // short
-        assertEquals((short)(0 + 32768), exec("short x = 0; x += 32768; return x;"));
-        assertEquals((short)(0 + -32769), exec("short x = 0; x += -32769; return x;"));
-        
-        // char
-        assertEquals((char)(0 + 65536), exec("char x = 0; x += 65536; return x;"));
-        assertEquals((char)(0 + -65536), exec("char x = 0; x += -65536; return x;"));
-        
+    public void testAssignmentAdditionOverflow() {        
         // int
         assertEquals(1 + 2147483647, exec("int x = 1; x += 2147483647; return x;"));
         assertEquals(-2 + -2147483647, exec("int x = -2; x += -2147483647; return x;"));
@@ -54,19 +42,7 @@ public class IntegerOverflowEnabledTests extends ScriptTestCase {
         assertEquals(-2L + -9223372036854775807L, exec("long x = -2; x += -9223372036854775807L; return x;"));
     }
     
-    public void testAssignmentSubtractionOverflow() {
-        // byte
-        assertEquals((byte)(0 - -128), exec("byte x = 0; x -= -128; return x;"));
-        assertEquals((byte)(0 - 129), exec("byte x = 0; x -= 129; return x;"));
-        
-        // short
-        assertEquals((short)(0 - -32768), exec("short x = 0; x -= -32768; return x;"));
-        assertEquals((short)(0 - 32769), exec("short x = 0; x -= 32769; return x;"));
-        
-        // char
-        assertEquals((char)(0 - -65536), exec("char x = 0; x -= -65536; return x;"));
-        assertEquals((char)(0 - 65536), exec("char x = 0; x -= 65536; return x;"));
-        
+    public void testAssignmentSubtractionOverflow() {        
         // int
         assertEquals(1 - -2147483647, exec("int x = 1; x -= -2147483647; return x;"));
         assertEquals(-2 - 2147483647, exec("int x = -2; x -= 2147483647; return x;"));
@@ -77,14 +53,6 @@ public class IntegerOverflowEnabledTests extends ScriptTestCase {
     }
     
     public void testAssignmentMultiplicationOverflow() {
-        // byte
-        assertEquals((byte) (2 * 128), exec("byte x = 2; x *= 128; return x;"));
-        assertEquals((byte) (2 * -128), exec("byte x = 2; x *= -128; return x;"));
-        
-        // char
-        assertEquals((char) (2 * 65536), exec("char x = 2; x *= 65536; return x;"));
-        assertEquals((char) (2 * -65536), exec("char x = 2; x *= -65536; return x;"));
-        
         // int
         assertEquals(2 * 2147483647, exec("int x = 2; x *= 2147483647; return x;"));
         assertEquals(2 * -2147483647, exec("int x = 2; x *= -2147483647; return x;"));
@@ -95,14 +63,6 @@ public class IntegerOverflowEnabledTests extends ScriptTestCase {
     }
     
     public void testAssignmentDivisionOverflow() {
-        // byte
-        assertEquals((byte) (-128 / -1), exec("byte x = (byte) -128; x /= -1; return x;"));
-
-        // short
-        assertEquals((short) (-32768 / -1), exec("short x = (short) -32768; x /= -1; return x;"));
-        
-        // cannot happen for char: unsigned
-        
         // int
         assertEquals((-2147483647 - 1) / -1, exec("int x = -2147483647 - 1; x /= -1; return x;"));
         
@@ -111,24 +71,6 @@ public class IntegerOverflowEnabledTests extends ScriptTestCase {
     }
     
     public void testIncrementOverFlow() throws Exception {
-        // byte
-        assertEquals((byte) 128, exec("byte x = 127; ++x; return x;"));
-        assertEquals((byte) 128, exec("byte x = 127; x++; return x;"));
-        assertEquals((byte) -129, exec("byte x = (byte) -128; --x; return x;"));
-        assertEquals((byte) -129, exec("byte x = (byte) -128; x--; return x;"));
-        
-        // short
-        assertEquals((short) 32768, exec("short x = 32767; ++x; return x;"));
-        assertEquals((short) 32768, exec("short x = 32767; x++; return x;"));
-        assertEquals((short) -32769, exec("short x = (short) -32768; --x; return x;"));
-        assertEquals((short) -32769, exec("short x = (short) -32768; x--; return x;"));
-        
-        // char
-        assertEquals((char) 65536, exec("char x = 65535; ++x; return x;"));
-        assertEquals((char) 65536, exec("char x = 65535; x++; return x;"));
-        assertEquals((char) -1, exec("char x = (char) 0; --x; return x;"));
-        assertEquals((char) -1, exec("char x = (char) 0; x--; return x;"));
-        
         // int
         assertEquals(2147483647 + 1, exec("int x = 2147483647; ++x; return x;"));        
         assertEquals(2147483647 + 1, exec("int x = 2147483647; x++; return x;"));

--- a/src/test/java/org/elasticsearch/plan/a/IntegerOverflowDisabledTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/IntegerOverflowDisabledTests.java
@@ -21,14 +21,14 @@ package org.elasticsearch.plan.a;
 
 import org.elasticsearch.common.settings.Settings;
 
-/** Tests overflow with integer overflow disabled */
+/** Tests integer overflow with numeric overflow disabled */
 public class IntegerOverflowDisabledTests extends ScriptTestCase {
     
     @Override
     protected Settings getSettings() {
         Settings.Builder builder = Settings.builder();
         builder.put(super.getSettings());
-        builder.put(PlanAScriptEngineService.INTEGER_OVERFLOW, false);
+        builder.put(PlanAScriptEngineService.NUMERIC_OVERFLOW, false);
         return builder.build();
     }
 
@@ -395,7 +395,7 @@ public class IntegerOverflowDisabledTests extends ScriptTestCase {
         } catch (ArithmeticException expected) {}
     }
 
-    public void testOverflow() throws Exception {
+    public void testDivision() throws Exception {
         try {
             exec("int x = -2147483647 - 1; int y = -1; return x / y;");
             fail("should have hit exception");
@@ -407,7 +407,7 @@ public class IntegerOverflowDisabledTests extends ScriptTestCase {
         } catch (ArithmeticException expected) {}
     }
     
-    public void testOverflowConst() throws Exception {
+    public void testDivisionConst() throws Exception {
         try {
             exec("return (-2147483647 - 1) / -1;");
             fail("should have hit exception");

--- a/src/test/java/org/elasticsearch/plan/a/ScriptTestCase.java
+++ b/src/test/java/org/elasticsearch/plan/a/ScriptTestCase.java
@@ -38,7 +38,7 @@ public abstract class ScriptTestCase extends ESTestCase {
     /** Override to provide different compiler settings */
     protected Settings getSettings() {
         Settings.Builder builder = Settings.builder();
-        builder.put(PlanAScriptEngineService.INTEGER_OVERFLOW, random().nextBoolean());
+        builder.put(PlanAScriptEngineService.NUMERIC_OVERFLOW, random().nextBoolean());
         return builder.build();
     }
 

--- a/src/test/java/org/elasticsearch/plan/a/UtilityTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/UtilityTests.java
@@ -101,4 +101,150 @@ public class UtilityTests extends ESTestCase {
             fail("did not get expected exception");
         } catch (ArithmeticException expected) {}
     }
+    
+    public void testAddWithoutOverflowFloat() {
+        assertEquals(10F, Utility.addWithoutOverflow(5F, 5F), 0F);
+        assertTrue(Float.isNaN(Utility.addWithoutOverflow(5F, Float.NaN)));
+        assertTrue(Float.isNaN(Utility.addWithoutOverflow(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY)));
+
+        try {
+            Utility.addWithoutOverflow(Float.MAX_VALUE, Float.MAX_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.addWithoutOverflow(-Float.MAX_VALUE, -Float.MAX_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testAddWithoutOverflowDouble() {
+        assertEquals(10D, Utility.addWithoutOverflow(5D, 5D), 0D);
+        assertTrue(Double.isNaN(Utility.addWithoutOverflow(5D, Double.NaN)));
+        assertTrue(Double.isNaN(Utility.addWithoutOverflow(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)));
+        
+        try {
+            Utility.addWithoutOverflow(Double.MAX_VALUE, Double.MAX_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.addWithoutOverflow(-Double.MAX_VALUE, -Double.MAX_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testSubtractWithoutOverflowFloat() {
+        assertEquals(5F, Utility.subtractWithoutOverflow(10F, 5F), 0F);
+        assertTrue(Float.isNaN(Utility.subtractWithoutOverflow(5F, Float.NaN)));
+        assertTrue(Float.isNaN(Utility.subtractWithoutOverflow(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)));
+
+        try {
+            Utility.subtractWithoutOverflow(Float.MAX_VALUE, -Float.MAX_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.subtractWithoutOverflow(-Float.MAX_VALUE, Float.MAX_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testSubtractWithoutOverflowDouble() {
+        assertEquals(5D, Utility.subtractWithoutOverflow(10D, 5D), 0D);
+        assertTrue(Double.isNaN(Utility.subtractWithoutOverflow(5D, Double.NaN)));
+        assertTrue(Double.isNaN(Utility.subtractWithoutOverflow(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY)));
+        
+        try {
+            Utility.subtractWithoutOverflow(Double.MAX_VALUE, -Double.MAX_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.subtractWithoutOverflow(-Double.MAX_VALUE, Double.MAX_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testMultiplyWithoutOverflowFloat() {
+        assertEquals(25F, Utility.multiplyWithoutOverflow(5F, 5F), 0F);
+        assertTrue(Float.isNaN(Utility.multiplyWithoutOverflow(5F, Float.NaN)));
+        assertEquals(Float.POSITIVE_INFINITY, Utility.multiplyWithoutOverflow(5F, Float.POSITIVE_INFINITY), 0F);
+
+        try {
+            Utility.multiplyWithoutOverflow(Float.MAX_VALUE, Float.MAX_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testMultiplyWithoutOverflowDouble() {
+        assertEquals(25D, Utility.multiplyWithoutOverflow(5D, 5D), 0D);
+        assertTrue(Double.isNaN(Utility.multiplyWithoutOverflow(5D, Double.NaN)));
+        assertEquals(Double.POSITIVE_INFINITY, Utility.multiplyWithoutOverflow(5D, Double.POSITIVE_INFINITY), 0D);
+        
+        try {
+            Utility.multiplyWithoutOverflow(Double.MAX_VALUE, Double.MAX_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testDivideWithoutOverflowFloat() {
+        assertEquals(5F, Utility.divideWithoutOverflow(25F, 5F), 0F);
+        assertTrue(Float.isNaN(Utility.divideWithoutOverflow(5F, Float.NaN)));
+        assertEquals(Float.POSITIVE_INFINITY, Utility.divideWithoutOverflow(Float.POSITIVE_INFINITY, 5F), 0F);
+
+        try {
+            Utility.divideWithoutOverflow(Float.MAX_VALUE, Float.MIN_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.divideWithoutOverflow(0F, 0F);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.divideWithoutOverflow(5F, 0F);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testDivideWithoutOverflowDouble() {
+        assertEquals(5D, Utility.divideWithoutOverflow(25D, 5D), 0D);
+        assertTrue(Double.isNaN(Utility.divideWithoutOverflow(5D, Double.NaN)));
+        assertEquals(Double.POSITIVE_INFINITY, Utility.divideWithoutOverflow(Double.POSITIVE_INFINITY, 5D), 0D);
+        
+        try {
+            Utility.divideWithoutOverflow(Double.MAX_VALUE, Double.MIN_VALUE);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.divideWithoutOverflow(0D, 0D);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+        
+        try {
+            Utility.divideWithoutOverflow(5D, 0D);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testRemainderWithoutOverflowFloat() {
+        assertEquals(1F, Utility.remainderWithoutOverflow(25F, 4F), 0F);
+        
+        try {
+            Utility.remainderWithoutOverflow(5F, 0F);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
+    
+    public void testRemainderWithoutOverflowDouble() {
+        assertEquals(1D, Utility.remainderWithoutOverflow(25D, 4D), 0D);
+        
+        try {
+            Utility.remainderWithoutOverflow(5D, 0D);
+            fail("did not get expected exception");
+        } catch (ArithmeticException expected) {}
+    }
 }


### PR DESCRIPTION
This renames `integer_overflow` option to `numeric_overflow` and adds checks for floats. 

when overflow is disabled, Infinite and NaN values cannot be created by any operator from finite values, except by explicit cast, e.g. `float f = (float) hugeDouble`. 

We may want to fix that too, and it would allow a lot of other cleanups. I would just emit things like `toIntExact` instead of `L2I` and so on. But this needs to be a followup because its made tricky by the fact we do binary promotion on the shift operators.