### PR TITLE
Allow string constants to be used with methods.

### DIFF
--- a/src/main/java/org/elasticsearch/plan/a/Adapter.java
+++ b/src/main/java/org/elasticsearch/plan/a/Adapter.java
@@ -100,6 +100,7 @@ class Adapter {
         Type current;
         boolean statik;
         boolean statement;
+        Object constant;
 
         private ExternalMetadata(final ParserRuleContext source) {
             this.source = source;
@@ -114,6 +115,7 @@ class Adapter {
             current = null;
             statik = false;
             statement = false;
+            constant = null;
         }
     }
 

--- a/src/main/java/org/elasticsearch/plan/a/Def.java
+++ b/src/main/java/org/elasticsearch/plan/a/Def.java
@@ -309,36 +309,203 @@ public class Def {
         return null;
     }
 
-    public static Object add(final Object left, final Object right, final boolean overflow) {
-        if (left instanceof String || right instanceof String) {
-            return "" + left + right;
-        } else if (left instanceof Number) {
+    public static Object not(final Object unary) {
+        if (unary instanceof Double || unary instanceof Float || unary instanceof Long) {
+            return ~((Number)unary).longValue();
+        } else if (unary instanceof Number) {
+            return ~((Number)unary).intValue();
+        } else if (unary instanceof Character) {
+            return ~(int)(char)unary;
+        }
+
+        throw new ClassCastException("Cannot apply [~] operation to type " +
+                "[" + unary.getClass().getCanonicalName() + "].");
+    }
+
+    public static Object neg(final Object unary) {
+        if (unary instanceof Double) {
+            return -(double)unary;
+        } else if (unary instanceof Float) {
+            return -(float)unary;
+        } else if (unary instanceof Long) {
+            return -(long)unary;
+        } else if (unary instanceof Number) {
+            return -((Number)unary).intValue();
+        } else if (unary instanceof Character) {
+            return -(char)unary;
+        }
+
+        throw new ClassCastException("Cannot apply [-] operation to type " +
+                "[" + unary.getClass().getCanonicalName() + "].");
+    }
+
+    public static Object mul(final Object left, final Object right) {
+        if (left instanceof Number) {
             if (right instanceof Number) {
-                if (overflow) {
-                    return ((Number)left).doubleValue() + ((Number)right).doubleValue();
+                if (left instanceof Double || right instanceof Double) {
+                    return ((Number)left).doubleValue() * ((Number)right).doubleValue();
+                } else if (left instanceof Float || right instanceof Float) {
+                    return ((Number)left).floatValue() * ((Number)right).floatValue();
+                } else if (left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() * ((Number)right).longValue();
                 } else {
-                    return Utility.addWithoutOverflow(((Number)left).doubleValue(), ((Number)right).doubleValue());
+                    return ((Number)left).intValue() * ((Number)right).intValue();
                 }
             } else if (right instanceof Character) {
-                if (overflow) {
-                    return ((Number)left).doubleValue() + (double)(char)right;
+                if (left instanceof Double) {
+                    return ((Number)left).doubleValue() * (double)(char)right;
+                } else if (left instanceof Float) {
+                    return ((Number)left).floatValue() * (float)(char)right;
+                } else if (left instanceof Long) {
+                    return ((Number)left).longValue() * (long)(char)right;
                 } else {
-                    return Utility.addWithoutOverflow(((Number)left).doubleValue(), (double)(char)right);
+                    return ((Number)left).intValue() * (int)(char)right;
                 }
             }
         } else if (left instanceof Character) {
             if (right instanceof Number) {
-                if (overflow) {
-                    return (double)(char)left + ((Number)right).doubleValue();
+                if (right instanceof Double) {
+                    return (double)(char)left * ((Number)right).doubleValue();
+                } else if (right instanceof Float) {
+                    return (float)(char)left * ((Number)right).floatValue();
+                } else if (right instanceof Long) {
+                    return (long)(char)left * ((Number)right).longValue();
                 } else {
-                    return Utility.addWithoutOverflow((double)(char)left, ((Number)right).doubleValue());
+                    return (int)(char)left * ((Number)right).intValue();
                 }
             } else if (right instanceof Character) {
-                if (overflow) {
-                    return (double)(char)left + (double)(char)right;
+                return (int)(char)left * (int)(char)right;
+            }
+        }
+
+        throw new ClassCastException("Cannot apply [*] operation to types " +
+                "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
+    }
+
+    public static Object div(final Object left, final Object right) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
+                if (left instanceof Double || right instanceof Double) {
+                    return ((Number)left).doubleValue() / ((Number)right).doubleValue();
+                } else if (left instanceof Float || right instanceof Float) {
+                    return ((Number)left).floatValue() / ((Number)right).floatValue();
+                } else if (left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() / ((Number)right).longValue();
                 } else {
-                    return Utility.addWithoutOverflow((double)(char)left, (double)(char)right);
+                    return ((Number)left).intValue() / ((Number)right).intValue();
                 }
+            } else if (right instanceof Character) {
+                if (left instanceof Double) {
+                    return ((Number)left).doubleValue() / (double)(char)right;
+                } else if (left instanceof Float) {
+                    return ((Number)left).floatValue() / (float)(char)right;
+                } else if (left instanceof Long) {
+                    return ((Number)left).longValue() / (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() / (int)(char)right;
+                }
+            }
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
+                if (right instanceof Double) {
+                    return (double)(char)left / ((Number)right).doubleValue();
+                } else if (right instanceof Float) {
+                    return (float)(char)left / ((Number)right).floatValue();
+                } else if (right instanceof Long) {
+                    return (long)(char)left / ((Number)right).longValue();
+                } else {
+                    return (int)(char)left / ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                return (int)(char)left / (int)(char)right;
+            }
+        }
+
+        throw new ClassCastException("Cannot apply [/] operation to types " +
+                "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
+    }
+
+    public static Object rem(final Object left, final Object right) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
+                if (left instanceof Double || right instanceof Double) {
+                    return ((Number)left).doubleValue() % ((Number)right).doubleValue();
+                } else if (left instanceof Float || right instanceof Float) {
+                    return ((Number)left).floatValue() % ((Number)right).floatValue();
+                } else if (left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() % ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() % ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                if (left instanceof Double) {
+                    return ((Number)left).doubleValue() % (double)(char)right;
+                } else if (left instanceof Float) {
+                    return ((Number)left).floatValue() % (float)(char)right;
+                } else if (left instanceof Long) {
+                    return ((Number)left).longValue() % (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() % (int)(char)right;
+                }
+            }
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
+                if (right instanceof Double) {
+                    return (double)(char)left % ((Number)right).doubleValue();
+                } else if (right instanceof Float) {
+                    return (float)(char)left % ((Number)right).floatValue();
+                } else if (right instanceof Long) {
+                    return (long)(char)left % ((Number)right).longValue();
+                } else {
+                    return (int)(char)left % ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                return (int)(char)left % (int)(char)right;
+            }
+        }
+
+        throw new ClassCastException("Cannot apply [%] operation to types " +
+                "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
+    }
+    
+    public static Object add(final Object left, final Object right) {
+        if (left instanceof String || right instanceof String) {
+            return "" + left + right;
+        } else if (left instanceof Number) {
+            if (right instanceof Number) {
+                if (left instanceof Double || right instanceof Double) {
+                    return ((Number)left).doubleValue() + ((Number)right).doubleValue();
+                } else if (left instanceof Float || right instanceof Float) {
+                    return ((Number)left).floatValue() + ((Number)right).floatValue();
+                } else if (left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() + ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() + ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                if (left instanceof Double) {
+                    return ((Number)left).doubleValue() + (double)(char)right;
+                } else if (left instanceof Float) {
+                    return ((Number)left).floatValue() + (float)(char)right;
+                } else if (left instanceof Long) {
+                    return ((Number)left).longValue() + (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() + (int)(char)right;
+                }
+            }
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
+                if (right instanceof Double) {
+                    return (double)(char)left + ((Number)right).doubleValue();
+                } else if (right instanceof Float) {
+                    return (float)(char)left + ((Number)right).floatValue();
+                } else if (right instanceof Long) {
+                    return (long)(char)left + ((Number)right).longValue();
+                } else {
+                    return (int)(char)left + ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                return (int)(char)left + (int)(char)right;
             }
         }
 
@@ -346,24 +513,180 @@ public class Def {
                 "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
     }
 
+    public static Object sub(final Object left, final Object right) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
+                if (left instanceof Double || right instanceof Double) {
+                    return ((Number)left).doubleValue() - ((Number)right).doubleValue();
+                } else if (left instanceof Float || right instanceof Float) {
+                    return ((Number)left).floatValue() - ((Number)right).floatValue();
+                } else if (left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() - ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() - ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                if (left instanceof Double) {
+                    return ((Number)left).doubleValue() - (double)(char)right;
+                } else if (left instanceof Float) {
+                    return ((Number)left).floatValue() - (float)(char)right;
+                } else if (left instanceof Long) {
+                    return ((Number)left).longValue() - (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() - (int)(char)right;
+                }
+            }
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
+                if (right instanceof Double) {
+                    return (double)(char)left - ((Number)right).doubleValue();
+                } else if (right instanceof Float) {
+                    return (float)(char)left - ((Number)right).floatValue();
+                } else if (right instanceof Long) {
+                    return (long)(char)left - ((Number)right).longValue();
+                } else {
+                    return (int)(char)left - ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                return (int)(char)left - (int)(char)right;
+            }
+        }
+
+        throw new ClassCastException("Cannot apply [-] operation to types " +
+                "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
+    }
+
+    public static Object lsh(final Object left, final Object right) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
+                if (left instanceof Double || right instanceof Double ||
+                        left instanceof Float || right instanceof Float ||
+                        left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() << ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() << ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                if (left instanceof Double || left instanceof Float || left instanceof Long) {
+                    return ((Number)left).longValue() << (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() << (int)(char)right;
+                }
+            }
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
+                if (right instanceof Double || right instanceof Float || right instanceof Long) {
+                    return (long)(char)left << ((Number)right).longValue();
+                } else {
+                    return (int)(char)left << ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                return (int)(char)left << (int)(char)right;
+            }
+        }
+
+        throw new ClassCastException("Cannot apply [<<] operation to types " +
+                "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
+    }
+
+    public static Object rsh(final Object left, final Object right) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
+                if (left instanceof Double || right instanceof Double ||
+                        left instanceof Float || right instanceof Float ||
+                        left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() >> ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() >> ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                if (left instanceof Double || left instanceof Float || left instanceof Long) {
+                    return ((Number)left).longValue() >> (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() >> (int)(char)right;
+                }
+            }
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
+                if (right instanceof Double || right instanceof Float || right instanceof Long) {
+                    return (long)(char)left >> ((Number)right).longValue();
+                } else {
+                    return (int)(char)left >> ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                return (int)(char)left >> (int)(char)right;
+            }
+        }
+
+        throw new ClassCastException("Cannot apply [>>] operation to types " +
+                "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
+    }
+
+    public static Object ush(final Object left, final Object right) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
+                if (left instanceof Double || right instanceof Double ||
+                        left instanceof Float || right instanceof Float ||
+                        left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() >>> ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() >>> ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                if (left instanceof Double || left instanceof Float || left instanceof Long) {
+                    return ((Number)left).longValue() >>> (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() >>> (int)(char)right;
+                }
+            }
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
+                if (right instanceof Double || right instanceof Float || right instanceof Long) {
+                    return (long)(char)left >>> ((Number)right).longValue();
+                } else {
+                    return (int)(char)left >>> ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                return (int)(char)left >>> (int)(char)right;
+            }
+        }
+
+        throw new ClassCastException("Cannot apply [>>>] operation to types " +
+                "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
+    }
+    
     public static Object and(final Object left, final Object right) {
         if (left instanceof Boolean && right instanceof Boolean) {
             return (boolean)left && (boolean)right;
         } else if (left instanceof Number) {
             if (right instanceof Number) {
-                return ((Number)left).longValue() & ((Number)right).longValue();
+                if (left instanceof Double || right instanceof Double ||
+                        left instanceof Float || right instanceof Float ||
+                        left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() & ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() & ((Number)right).intValue();
+                }
             } else if (right instanceof Character) {
-                return ((Number)left).longValue() & (long)(char)right;
+                if (left instanceof Double || left instanceof Float || left instanceof Long) {
+                    return ((Number)left).longValue() & (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() & (int)(char)right;
+                }
             }
         } else if (left instanceof Character) {
             if (right instanceof Number) {
-                return (long)(char)left & ((Number)right).longValue();
+                if (right instanceof Double || right instanceof Float || right instanceof Long) {
+                    return (long)(char)left & ((Number)right).longValue();
+                } else {
+                    return (int)(char)left & ((Number)right).intValue();
+                }
             } else if (right instanceof Character) {
-                return (long)(char)left & (long)(char)right;
+                return (int)(char)left & (int)(char)right;
             }
         }
 
-        throw new ClassCastException("Cannot apply [^] operation to types " +
+        throw new ClassCastException("Cannot apply [&] operation to types " +
                 "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
     }
 
@@ -372,15 +695,29 @@ public class Def {
             return (boolean)left ^ (boolean)right;
         } else if (left instanceof Number) {
             if (right instanceof Number) {
-                return ((Number)left).longValue() ^ ((Number)right).longValue();
+                if (left instanceof Double || right instanceof Double ||
+                        left instanceof Float || right instanceof Float ||
+                        left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() ^ ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() ^ ((Number)right).intValue();
+                }
             } else if (right instanceof Character) {
-                return ((Number)left).longValue() ^ (long)(char)right;
+                if (left instanceof Double || left instanceof Float || left instanceof Long) {
+                    return ((Number)left).longValue() ^ (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() ^ (int)(char)right;
+                }
             }
         } else if (left instanceof Character) {
             if (right instanceof Number) {
-                return (long)(char)left ^ ((Number)right).longValue();
+                if (right instanceof Double || right instanceof Float || right instanceof Long) {
+                    return (long)(char)left ^ ((Number)right).longValue();
+                } else {
+                    return (int)(char)left ^ ((Number)right).intValue();
+                }
             } else if (right instanceof Character) {
-                return (long)(char)left ^ (long)(char)right;
+                return (int)(char)left ^ (int)(char)right;
             }
         }
 
@@ -393,19 +730,261 @@ public class Def {
             return (boolean)left || (boolean)right;
         } else if (left instanceof Number) {
             if (right instanceof Number) {
-                return ((Number)left).longValue() | ((Number)right).longValue();
+                if (left instanceof Double || right instanceof Double ||
+                        left instanceof Float || right instanceof Float ||
+                        left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() | ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() | ((Number)right).intValue();
+                }
             } else if (right instanceof Character) {
-                return ((Number)left).longValue() | (long)(char)right;
+                if (left instanceof Double || left instanceof Float || left instanceof Long) {
+                    return ((Number)left).longValue() | (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() | (int)(char)right;
+                }
             }
         } else if (left instanceof Character) {
             if (right instanceof Number) {
-                return (long)(char)left | ((Number)right).longValue();
+                if (right instanceof Double || right instanceof Float || right instanceof Long) {
+                    return (long)(char)left | ((Number)right).longValue();
+                } else {
+                    return (int)(char)left | ((Number)right).intValue();
+                }
             } else if (right instanceof Character) {
-                return (long)(char)left | (long)(char)right;
+                return (int)(char)left | (int)(char)right;
             }
         }
 
-        throw new ClassCastException("Cannot apply [^] operation to types " +
+        throw new ClassCastException("Cannot apply [|] operation to types " +
+                "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
+    }
+
+    public static boolean eq(final Object left, final Object right) {
+        if (left != null && right != null) {
+            if (left instanceof Double) {
+                if (right instanceof Number) {
+                    return (double)left == ((Number)right).doubleValue();
+                } else if (right instanceof Character) {
+                    return (double)left == (double)(char)right;
+                }
+            } else if (right instanceof Double) {
+                if (left instanceof Number) {
+                    return ((Number)left).doubleValue() == (double)right;
+                } else if (left instanceof Character) {
+                    return (double)(char)left == ((Number)right).doubleValue();
+                }
+            } else if (left instanceof Float) {
+                if (right instanceof Number) {
+                    return (float)left == ((Number)right).floatValue();
+                } else if (right instanceof Character) {
+                    return (float)left == (float)(char)right;
+                }
+            } else if (right instanceof Float) {
+                if (left instanceof Number) {
+                    return ((Number)left).floatValue() == (float)right;
+                } else if (left instanceof Character) {
+                    return (float)(char)left == ((Number)right).floatValue();
+                }
+            } else if (left instanceof Long) {
+                if (right instanceof Number) {
+                    return (long)left == ((Number)right).longValue();
+                } else if (right instanceof Character) {
+                    return (long)left == (long)(char)right;
+                }
+            } else if (right instanceof Long) {
+                if (left instanceof Number) {
+                    return ((Number)left).longValue() == (long)right;
+                } else if (left instanceof Character) {
+                    return (long)(char)left == ((Number)right).longValue();
+                }
+            } else if (left instanceof Number) {
+                if (right instanceof Number) {
+                    return ((Number)left).intValue() == ((Number)right).intValue();
+                } else if (right instanceof Character) {
+                    return ((Number)left).intValue() == (int)(char)right;
+                }
+            } else if (right instanceof Number && left instanceof Character) {
+                return (int)(char)left == ((Number)right).intValue();
+            } else if (left instanceof Character && right instanceof Character) {
+                return (int)(char)left == (int)(char)right;
+            }
+
+            return left.equals(right);
+        }
+
+        return left == null && right == null;
+    }
+
+    public static boolean lt(final Object left, final Object right) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
+                if (left instanceof Double || right instanceof Double) {
+                    return ((Number)left).doubleValue() < ((Number)right).doubleValue();
+                } else if (left instanceof Float || right instanceof Float) {
+                    return ((Number)left).floatValue() < ((Number)right).floatValue();
+                } else if (left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() < ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() < ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                if (left instanceof Double) {
+                    return ((Number)left).doubleValue() < (double)(char)right;
+                } else if (left instanceof Float) {
+                    return ((Number)left).floatValue() < (float)(char)right;
+                } else if (left instanceof Long) {
+                    return ((Number)left).longValue() < (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() < (int)(char)right;
+                }
+            }
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
+                if (right instanceof Double) {
+                    return (double)(char)left < ((Number)right).doubleValue();
+                } else if (right instanceof Float) {
+                    return (float)(char)left < ((Number)right).floatValue();
+                } else if (right instanceof Long) {
+                    return (long)(char)left < ((Number)right).longValue();
+                } else {
+                    return (int)(char)left < ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                return (int)(char)left < (int)(char)right;
+            }
+        }
+
+        throw new ClassCastException("Cannot apply [<] operation to types " +
+                "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
+    }
+
+    public static boolean lte(final Object left, final Object right) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
+                if (left instanceof Double || right instanceof Double) {
+                    return ((Number)left).doubleValue() <= ((Number)right).doubleValue();
+                } else if (left instanceof Float || right instanceof Float) {
+                    return ((Number)left).floatValue() <= ((Number)right).floatValue();
+                } else if (left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() <= ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() <= ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                if (left instanceof Double) {
+                    return ((Number)left).doubleValue() <= (double)(char)right;
+                } else if (left instanceof Float) {
+                    return ((Number)left).floatValue() <= (float)(char)right;
+                } else if (left instanceof Long) {
+                    return ((Number)left).longValue() <= (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() <= (int)(char)right;
+                }
+            }
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
+                if (right instanceof Double) {
+                    return (double)(char)left <= ((Number)right).doubleValue();
+                } else if (right instanceof Float) {
+                    return (float)(char)left <= ((Number)right).floatValue();
+                } else if (right instanceof Long) {
+                    return (long)(char)left <= ((Number)right).longValue();
+                } else {
+                    return (int)(char)left <= ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                return (int)(char)left <= (int)(char)right;
+            }
+        }
+
+        throw new ClassCastException("Cannot apply [<=] operation to types " +
+                "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
+    }
+
+    public static boolean gt(final Object left, final Object right) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
+                if (left instanceof Double || right instanceof Double) {
+                    return ((Number)left).doubleValue() > ((Number)right).doubleValue();
+                } else if (left instanceof Float || right instanceof Float) {
+                    return ((Number)left).floatValue() > ((Number)right).floatValue();
+                } else if (left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() > ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() > ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                if (left instanceof Double) {
+                    return ((Number)left).doubleValue() > (double)(char)right;
+                } else if (left instanceof Float) {
+                    return ((Number)left).floatValue() > (float)(char)right;
+                } else if (left instanceof Long) {
+                    return ((Number)left).longValue() > (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() > (int)(char)right;
+                }
+            }
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
+                if (right instanceof Double) {
+                    return (double)(char)left > ((Number)right).doubleValue();
+                } else if (right instanceof Float) {
+                    return (float)(char)left > ((Number)right).floatValue();
+                } else if (right instanceof Long) {
+                    return (long)(char)left > ((Number)right).longValue();
+                } else {
+                    return (int)(char)left > ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                return (int)(char)left > (int)(char)right;
+            }
+        }
+
+        throw new ClassCastException("Cannot apply [>] operation to types " +
+                "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
+    }
+
+    public static boolean gte(final Object left, final Object right) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
+                if (left instanceof Double || right instanceof Double) {
+                    return ((Number)left).doubleValue() >= ((Number)right).doubleValue();
+                } else if (left instanceof Float || right instanceof Float) {
+                    return ((Number)left).floatValue() >= ((Number)right).floatValue();
+                } else if (left instanceof Long || right instanceof Long) {
+                    return ((Number)left).longValue() >= ((Number)right).longValue();
+                } else {
+                    return ((Number)left).intValue() >= ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                if (left instanceof Double) {
+                    return ((Number)left).doubleValue() >= (double)(char)right;
+                } else if (left instanceof Float) {
+                    return ((Number)left).floatValue() >= (float)(char)right;
+                } else if (left instanceof Long) {
+                    return ((Number)left).longValue() >= (long)(char)right;
+                } else {
+                    return ((Number)left).intValue() >= (int)(char)right;
+                }
+            }
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
+                if (right instanceof Double) {
+                    return (double)(char)left >= ((Number)right).doubleValue();
+                } else if (right instanceof Float) {
+                    return (float)(char)left >= ((Number)right).floatValue();
+                } else if (right instanceof Long) {
+                    return (long)(char)left >= ((Number)right).longValue();
+                } else {
+                    return (int)(char)left >= ((Number)right).intValue();
+                }
+            } else if (right instanceof Character) {
+                return (int)(char)left >= (int)(char)right;
+            }
+        }
+
+        throw new ClassCastException("Cannot apply [>] operation to types " +
                 "[" + left.getClass().getCanonicalName() + "] and [" + right.getClass().getCanonicalName() + "].");
     }
 

--- a/src/main/java/org/elasticsearch/plan/a/PlanA.g4
+++ b/src/main/java/org/elasticsearch/plan/a/PlanA.g4
@@ -78,7 +78,6 @@ id
 expression
     :               LP expression RP                                    # precedence
     |               ( OCTAL | HEX | INTEGER | DECIMAL )                 # numeric
-    |               STRING                                              # string
     |               CHAR                                                # char
     |               TRUE                                                # true
     |               FALSE                                               # false
@@ -108,18 +107,21 @@ extstart
    : extprec
    | extcast
    | exttype
-   | extmember
+   | extvar
    | extnew
+   | extstring
    ;
 
-extprec:   LP ( extprec | extcast | exttype | extmember | extnew ) RP ( extdot | extbrace )?;
-extcast:   LP decltype RP ( extprec | extcast | exttype | extmember | extnew );
+extprec:   LP ( extprec | extcast | exttype | extvar | extnew | extstring ) RP ( extdot | extbrace )?;
+extcast:   LP decltype RP ( extprec | extcast | exttype | extvar | extnew | extstring );
 extbrace:  LBRACE expression RBRACE ( extdot | extbrace )?;
 extdot:    DOT ( extcall | extmember );
 exttype:   type extdot;
 extcall:   id arguments ( extdot | extbrace )?;
+extvar:    id (extdot | extbrace )?;
 extmember: id (extdot | extbrace )?;
 extnew:    NEW type ( ( arguments ( extdot | extbrace)? ) | ( ( LBRACE expression RBRACE )+ extdot? ) );
+extstring: STRING (extdot | extbrace )?;
 
 arguments
     : ( LP ( expression ( COMMA expression )* )? RP )

--- a/src/main/java/org/elasticsearch/plan/a/PlanA.g4
+++ b/src/main/java/org/elasticsearch/plan/a/PlanA.g4
@@ -115,11 +115,11 @@ extstart
 extprec:   LP ( extprec | extcast | exttype | extvar | extnew | extstring ) RP ( extdot | extbrace )?;
 extcast:   LP decltype RP ( extprec | extcast | exttype | extvar | extnew | extstring );
 extbrace:  LBRACE expression RBRACE ( extdot | extbrace )?;
-extdot:    DOT ( extcall | extmember );
+extdot:    DOT ( extcall | extfield );
 exttype:   type extdot;
 extcall:   id arguments ( extdot | extbrace )?;
 extvar:    id (extdot | extbrace )?;
-extmember: id (extdot | extbrace )?;
+extfield:  ( id | INTEGER ) (extdot | extbrace )?;
 extnew:    NEW type ( ( arguments ( extdot | extbrace)? ) | ( ( LBRACE expression RBRACE )+ extdot? ) );
 extstring: STRING (extdot | extbrace )?;
 

--- a/src/main/java/org/elasticsearch/plan/a/PlanABaseVisitor.java
+++ b/src/main/java/org/elasticsearch/plan/a/PlanABaseVisitor.java
@@ -328,7 +328,7 @@ class PlanABaseVisitor<T> extends AbstractParseTreeVisitor<T> implements PlanAVi
    * <p>The default implementation returns the result of calling
    * {@link #visitChildren} on {@code ctx}.</p>
    */
-  @Override public T visitExtmember(PlanAParser.ExtmemberContext ctx) { return visitChildren(ctx); }
+  @Override public T visitExtfield(PlanAParser.ExtfieldContext ctx) { return visitChildren(ctx); }
   /**
    * {@inheritDoc}
    *

--- a/src/main/java/org/elasticsearch/plan/a/PlanABaseVisitor.java
+++ b/src/main/java/org/elasticsearch/plan/a/PlanABaseVisitor.java
@@ -167,13 +167,6 @@ class PlanABaseVisitor<T> extends AbstractParseTreeVisitor<T> implements PlanAVi
    * <p>The default implementation returns the result of calling
    * {@link #visitChildren} on {@code ctx}.</p>
    */
-  @Override public T visitString(PlanAParser.StringContext ctx) { return visitChildren(ctx); }
-  /**
-   * {@inheritDoc}
-   *
-   * <p>The default implementation returns the result of calling
-   * {@link #visitChildren} on {@code ctx}.</p>
-   */
   @Override public T visitBool(PlanAParser.BoolContext ctx) { return visitChildren(ctx); }
   /**
    * {@inheritDoc}
@@ -328,6 +321,13 @@ class PlanABaseVisitor<T> extends AbstractParseTreeVisitor<T> implements PlanAVi
    * <p>The default implementation returns the result of calling
    * {@link #visitChildren} on {@code ctx}.</p>
    */
+  @Override public T visitExtvar(PlanAParser.ExtvarContext ctx) { return visitChildren(ctx); }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   */
   @Override public T visitExtmember(PlanAParser.ExtmemberContext ctx) { return visitChildren(ctx); }
   /**
    * {@inheritDoc}
@@ -336,6 +336,13 @@ class PlanABaseVisitor<T> extends AbstractParseTreeVisitor<T> implements PlanAVi
    * {@link #visitChildren} on {@code ctx}.</p>
    */
   @Override public T visitExtnew(PlanAParser.ExtnewContext ctx) { return visitChildren(ctx); }
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The default implementation returns the result of calling
+   * {@link #visitChildren} on {@code ctx}.</p>
+   */
+  @Override public T visitExtstring(PlanAParser.ExtstringContext ctx) { return visitChildren(ctx); }
   /**
    * {@inheritDoc}
    *

--- a/src/main/java/org/elasticsearch/plan/a/PlanAParser.java
+++ b/src/main/java/org/elasticsearch/plan/a/PlanAParser.java
@@ -34,13 +34,13 @@ class PlanAParser extends Parser {
     RULE_afterthought = 5, RULE_declaration = 6, RULE_decltype = 7, RULE_declvar = 8, 
     RULE_type = 9, RULE_id = 10, RULE_expression = 11, RULE_extstart = 12, 
     RULE_extprec = 13, RULE_extcast = 14, RULE_extbrace = 15, RULE_extdot = 16, 
-    RULE_exttype = 17, RULE_extcall = 18, RULE_extvar = 19, RULE_extmember = 20, 
+    RULE_exttype = 17, RULE_extcall = 18, RULE_extvar = 19, RULE_extfield = 20, 
     RULE_extnew = 21, RULE_extstring = 22, RULE_arguments = 23, RULE_increment = 24;
   public static final String[] ruleNames = {
     "source", "statement", "block", "empty", "initializer", "afterthought", 
     "declaration", "decltype", "declvar", "type", "id", "expression", "extstart", 
     "extprec", "extcast", "extbrace", "extdot", "exttype", "extcall", "extvar", 
-    "extmember", "extnew", "extstring", "arguments", "increment"
+    "extfield", "extnew", "extstring", "arguments", "increment"
   };
 
   private static final String[] _LITERAL_NAMES = {
@@ -2052,8 +2052,8 @@ class PlanAParser extends Parser {
     public ExtcallContext extcall() {
       return getRuleContext(ExtcallContext.class,0);
     }
-    public ExtmemberContext extmember() {
-      return getRuleContext(ExtmemberContext.class,0);
+    public ExtfieldContext extfield() {
+      return getRuleContext(ExtfieldContext.class,0);
     }
     public ExtdotContext(ParserRuleContext parent, int invokingState) {
       super(parent, invokingState);
@@ -2085,7 +2085,7 @@ class PlanAParser extends Parser {
       case 2:
         {
         setState(287);
-        extmember();
+        extfield();
         }
         break;
       }
@@ -2262,46 +2262,60 @@ class PlanAParser extends Parser {
     return _localctx;
   }
 
-  public static class ExtmemberContext extends ParserRuleContext {
+  public static class ExtfieldContext extends ParserRuleContext {
     public IdContext id() {
       return getRuleContext(IdContext.class,0);
     }
+    public TerminalNode INTEGER() { return getToken(PlanAParser.INTEGER, 0); }
     public ExtdotContext extdot() {
       return getRuleContext(ExtdotContext.class,0);
     }
     public ExtbraceContext extbrace() {
       return getRuleContext(ExtbraceContext.class,0);
     }
-    public ExtmemberContext(ParserRuleContext parent, int invokingState) {
+    public ExtfieldContext(ParserRuleContext parent, int invokingState) {
       super(parent, invokingState);
     }
-    @Override public int getRuleIndex() { return RULE_extmember; }
+    @Override public int getRuleIndex() { return RULE_extfield; }
     @Override
     public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-      if ( visitor instanceof PlanAVisitor ) return ((PlanAVisitor<? extends T>)visitor).visitExtmember(this);
+      if ( visitor instanceof PlanAVisitor ) return ((PlanAVisitor<? extends T>)visitor).visitExtfield(this);
       else return visitor.visitChildren(this);
     }
   }
 
-  public final ExtmemberContext extmember() throws RecognitionException {
-    ExtmemberContext _localctx = new ExtmemberContext(_ctx, getState());
-    enterRule(_localctx, 40, RULE_extmember);
+  public final ExtfieldContext extfield() throws RecognitionException {
+    ExtfieldContext _localctx = new ExtfieldContext(_ctx, getState());
+    enterRule(_localctx, 40, RULE_extfield);
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(304);
-      id();
-      setState(307);
+      setState(306);
       switch ( getInterpreter().adaptivePredict(_input,32,_ctx) ) {
       case 1:
         {
+        setState(304);
+        id();
+        }
+        break;
+      case 2:
+        {
         setState(305);
+        match(INTEGER);
+        }
+        break;
+      }
+      setState(310);
+      switch ( getInterpreter().adaptivePredict(_input,33,_ctx) ) {
+      case 1:
+        {
+        setState(308);
         extdot();
         }
         break;
       case 2:
         {
-        setState(306);
+        setState(309);
         extbrace();
         }
         break;
@@ -2365,28 +2379,28 @@ class PlanAParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(309);
+      setState(312);
       match(NEW);
-      setState(310);
+      setState(313);
       type();
-      setState(327);
+      setState(330);
       switch (_input.LA(1)) {
       case LP:
         {
         {
-        setState(311);
-        arguments();
         setState(314);
-        switch ( getInterpreter().adaptivePredict(_input,33,_ctx) ) {
+        arguments();
+        setState(317);
+        switch ( getInterpreter().adaptivePredict(_input,34,_ctx) ) {
         case 1:
           {
-          setState(312);
+          setState(315);
           extdot();
           }
           break;
         case 2:
           {
-          setState(313);
+          setState(316);
           extbrace();
           }
           break;
@@ -2397,7 +2411,7 @@ class PlanAParser extends Parser {
       case LBRACE:
         {
         {
-        setState(320); 
+        setState(323); 
         _errHandler.sync(this);
         _alt = 1;
         do {
@@ -2405,11 +2419,11 @@ class PlanAParser extends Parser {
           case 1:
             {
             {
-            setState(316);
+            setState(319);
             match(LBRACE);
-            setState(317);
+            setState(320);
             expression(0);
-            setState(318);
+            setState(321);
             match(RBRACE);
             }
             }
@@ -2417,15 +2431,15 @@ class PlanAParser extends Parser {
           default:
             throw new NoViableAltException(this);
           }
-          setState(322); 
+          setState(325); 
           _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,34,_ctx);
+          _alt = getInterpreter().adaptivePredict(_input,35,_ctx);
         } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
-        setState(325);
-        switch ( getInterpreter().adaptivePredict(_input,35,_ctx) ) {
+        setState(328);
+        switch ( getInterpreter().adaptivePredict(_input,36,_ctx) ) {
         case 1:
           {
-          setState(324);
+          setState(327);
           extdot();
           }
           break;
@@ -2474,19 +2488,19 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(329);
-      match(STRING);
       setState(332);
-      switch ( getInterpreter().adaptivePredict(_input,37,_ctx) ) {
+      match(STRING);
+      setState(335);
+      switch ( getInterpreter().adaptivePredict(_input,38,_ctx) ) {
       case 1:
         {
-        setState(330);
+        setState(333);
         extdot();
         }
         break;
       case 2:
         {
-        setState(331);
+        setState(334);
         extbrace();
         }
         break;
@@ -2536,34 +2550,34 @@ class PlanAParser extends Parser {
       enterOuterAlt(_localctx, 1);
       {
       {
-      setState(334);
+      setState(337);
       match(LP);
-      setState(343);
-      switch ( getInterpreter().adaptivePredict(_input,39,_ctx) ) {
+      setState(346);
+      switch ( getInterpreter().adaptivePredict(_input,40,_ctx) ) {
       case 1:
         {
-        setState(335);
+        setState(338);
         expression(0);
-        setState(340);
+        setState(343);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(336);
+          setState(339);
           match(COMMA);
-          setState(337);
+          setState(340);
           expression(0);
           }
           }
-          setState(342);
+          setState(345);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
         break;
       }
-      setState(345);
+      setState(348);
       match(RP);
       }
       }
@@ -2600,7 +2614,7 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(347);
+      setState(350);
       _la = _input.LA(1);
       if ( !(_la==INCR || _la==DECR) ) {
       _errHandler.recoverInline(this);
@@ -2676,7 +2690,7 @@ class PlanAParser extends Parser {
   }
 
   public static final String _serializedATN =
-    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3I\u0160\4\2\t\2\4"+
+    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3I\u0163\4\2\t\2\4"+
     "\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
     "\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
     "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
@@ -2698,117 +2712,118 @@ class PlanAParser extends Parser {
     "\20\3\20\3\20\3\20\3\20\3\20\5\20\u0117\n\20\3\21\3\21\3\21\3\21\3\21"+
     "\5\21\u011e\n\21\3\22\3\22\3\22\5\22\u0123\n\22\3\23\3\23\3\23\3\24\3"+
     "\24\3\24\3\24\5\24\u012c\n\24\3\25\3\25\3\25\5\25\u0131\n\25\3\26\3\26"+
-    "\3\26\5\26\u0136\n\26\3\27\3\27\3\27\3\27\3\27\5\27\u013d\n\27\3\27\3"+
-    "\27\3\27\3\27\6\27\u0143\n\27\r\27\16\27\u0144\3\27\5\27\u0148\n\27\5"+
-    "\27\u014a\n\27\3\30\3\30\3\30\5\30\u014f\n\30\3\31\3\31\3\31\3\31\7\31"+
-    "\u0155\n\31\f\31\16\31\u0158\13\31\5\31\u015a\n\31\3\31\3\31\3\32\3\32"+
-    "\3\32\2\3\30\33\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62"+
-    "\2\13\4\2\27\30\34\35\3\2\62=\3\2?B\3\2\31\33\3\2\34\35\3\2\36 \3\2!$"+
-    "\3\2%(\3\2\60\61\u019b\2\65\3\2\2\2\4|\3\2\2\2\6\u0087\3\2\2\2\b\u0089"+
-    "\3\2\2\2\n\u008d\3\2\2\2\f\u008f\3\2\2\2\16\u0091\3\2\2\2\20\u009a\3\2"+
-    "\2\2\22\u00a2\3\2\2\2\24\u00ab\3\2\2\2\26\u00ad\3\2\2\2\30\u00cc\3\2\2"+
-    "\2\32\u00fd\3\2\2\2\34\u00ff\3\2\2\2\36\u010d\3\2\2\2 \u0118\3\2\2\2\""+
-    "\u011f\3\2\2\2$\u0124\3\2\2\2&\u0127\3\2\2\2(\u012d\3\2\2\2*\u0132\3\2"+
-    "\2\2,\u0137\3\2\2\2.\u014b\3\2\2\2\60\u0150\3\2\2\2\62\u015d\3\2\2\2\64"+
-    "\66\5\4\3\2\65\64\3\2\2\2\66\67\3\2\2\2\67\65\3\2\2\2\678\3\2\2\289\3"+
-    "\2\2\29:\7\2\2\3:\3\3\2\2\2;<\7\16\2\2<=\7\t\2\2=>\5\30\r\2>?\7\n\2\2"+
-    "?B\5\6\4\2@A\7\17\2\2AC\5\6\4\2B@\3\2\2\2BC\3\2\2\2C}\3\2\2\2DE\7\20\2"+
-    "\2EF\7\t\2\2FG\5\30\r\2GJ\7\n\2\2HK\5\6\4\2IK\5\b\5\2JH\3\2\2\2JI\3\2"+
-    "\2\2K}\3\2\2\2LM\7\21\2\2MN\5\6\4\2NO\7\20\2\2OP\7\t\2\2PQ\5\30\r\2QS"+
-    "\7\n\2\2RT\7\r\2\2SR\3\2\2\2ST\3\2\2\2T}\3\2\2\2UV\7\22\2\2VX\7\t\2\2"+
-    "WY\5\n\6\2XW\3\2\2\2XY\3\2\2\2YZ\3\2\2\2Z\\\7\r\2\2[]\5\30\r\2\\[\3\2"+
-    "\2\2\\]\3\2\2\2]^\3\2\2\2^`\7\r\2\2_a\5\f\7\2`_\3\2\2\2`a\3\2\2\2ab\3"+
-    "\2\2\2be\7\n\2\2cf\5\6\4\2df\5\b\5\2ec\3\2\2\2ed\3\2\2\2f}\3\2\2\2gi\5"+
-    "\16\b\2hj\7\r\2\2ih\3\2\2\2ij\3\2\2\2j}\3\2\2\2km\7\23\2\2ln\7\r\2\2m"+
-    "l\3\2\2\2mn\3\2\2\2n}\3\2\2\2oq\7\24\2\2pr\7\r\2\2qp\3\2\2\2qr\3\2\2\2"+
-    "r}\3\2\2\2st\7\25\2\2tv\5\30\r\2uw\7\r\2\2vu\3\2\2\2vw\3\2\2\2w}\3\2\2"+
-    "\2xz\5\30\r\2y{\7\r\2\2zy\3\2\2\2z{\3\2\2\2{}\3\2\2\2|;\3\2\2\2|D\3\2"+
-    "\2\2|L\3\2\2\2|U\3\2\2\2|g\3\2\2\2|k\3\2\2\2|o\3\2\2\2|s\3\2\2\2|x\3\2"+
-    "\2\2}\5\3\2\2\2~\u0082\7\5\2\2\177\u0081\5\4\3\2\u0080\177\3\2\2\2\u0081"+
-    "\u0084\3\2\2\2\u0082\u0080\3\2\2\2\u0082\u0083\3\2\2\2\u0083\u0085\3\2"+
-    "\2\2\u0084\u0082\3\2\2\2\u0085\u0088\7\6\2\2\u0086\u0088\5\4\3\2\u0087"+
-    "~\3\2\2\2\u0087\u0086\3\2\2\2\u0088\7\3\2\2\2\u0089\u008a\7\r\2\2\u008a"+
-    "\t\3\2\2\2\u008b\u008e\5\16\b\2\u008c\u008e\5\30\r\2\u008d\u008b\3\2\2"+
-    "\2\u008d\u008c\3\2\2\2\u008e\13\3\2\2\2\u008f\u0090\5\30\r\2\u0090\r\3"+
-    "\2\2\2\u0091\u0092\5\20\t\2\u0092\u0097\5\22\n\2\u0093\u0094\7\f\2\2\u0094"+
-    "\u0096\5\22\n\2\u0095\u0093\3\2\2\2\u0096\u0099\3\2\2\2\u0097\u0095\3"+
-    "\2\2\2\u0097\u0098\3\2\2\2\u0098\17\3\2\2\2\u0099\u0097\3\2\2\2\u009a"+
-    "\u009f\5\24\13\2\u009b\u009c\7\7\2\2\u009c\u009e\7\b\2\2\u009d\u009b\3"+
-    "\2\2\2\u009e\u00a1\3\2\2\2\u009f\u009d\3\2\2\2\u009f\u00a0\3\2\2\2\u00a0"+
-    "\21\3\2\2\2\u00a1\u009f\3\2\2\2\u00a2\u00a5\5\26\f\2\u00a3\u00a4\7\62"+
-    "\2\2\u00a4\u00a6\5\30\r\2\u00a5\u00a3\3\2\2\2\u00a5\u00a6\3\2\2\2\u00a6"+
-    "\23\3\2\2\2\u00a7\u00a8\6\13\2\2\u00a8\u00ac\7H\2\2\u00a9\u00aa\6\13\3"+
-    "\2\u00aa\u00ac\7I\2\2\u00ab\u00a7\3\2\2\2\u00ab\u00a9\3\2\2\2\u00ac\25"+
-    "\3\2\2\2\u00ad\u00ae\6\f\4\2\u00ae\u00af\7H\2\2\u00af\27\3\2\2\2\u00b0"+
-    "\u00b1\b\r\1\2\u00b1\u00b2\t\2\2\2\u00b2\u00cd\5\30\r\20\u00b3\u00b4\7"+
-    "\t\2\2\u00b4\u00b5\5\20\t\2\u00b5\u00b6\7\n\2\2\u00b6\u00b7\5\30\r\17"+
-    "\u00b7\u00cd\3\2\2\2\u00b8\u00b9\5\32\16\2\u00b9\u00ba\t\3\2\2\u00ba\u00bb"+
-    "\5\30\r\3\u00bb\u00cd\3\2\2\2\u00bc\u00bd\7\t\2\2\u00bd\u00be\5\30\r\2"+
-    "\u00be\u00bf\7\n\2\2\u00bf\u00cd\3\2\2\2\u00c0\u00cd\t\4\2\2\u00c1\u00cd"+
-    "\7D\2\2\u00c2\u00cd\7E\2\2\u00c3\u00cd\7F\2\2\u00c4\u00cd\7G\2\2\u00c5"+
-    "\u00cd\5\32\16\2\u00c6\u00c7\5\32\16\2\u00c7\u00c8\5\62\32\2\u00c8\u00cd"+
-    "\3\2\2\2\u00c9\u00ca\5\62\32\2\u00ca\u00cb\5\32\16\2\u00cb\u00cd\3\2\2"+
-    "\2\u00cc\u00b0\3\2\2\2\u00cc\u00b3\3\2\2\2\u00cc\u00b8\3\2\2\2\u00cc\u00bc"+
-    "\3\2\2\2\u00cc\u00c0\3\2\2\2\u00cc\u00c1\3\2\2\2\u00cc\u00c2\3\2\2\2\u00cc"+
-    "\u00c3\3\2\2\2\u00cc\u00c4\3\2\2\2\u00cc\u00c5\3\2\2\2\u00cc\u00c6\3\2"+
-    "\2\2\u00cc\u00c9\3\2\2\2\u00cd\u00f4\3\2\2\2\u00ce\u00cf\f\16\2\2\u00cf"+
-    "\u00d0\t\5\2\2\u00d0\u00f3\5\30\r\17\u00d1\u00d2\f\r\2\2\u00d2\u00d3\t"+
-    "\6\2\2\u00d3\u00f3\5\30\r\16\u00d4\u00d5\f\f\2\2\u00d5\u00d6\t\7\2\2\u00d6"+
-    "\u00f3\5\30\r\r\u00d7\u00d8\f\13\2\2\u00d8\u00d9\t\b\2\2\u00d9\u00f3\5"+
-    "\30\r\f\u00da\u00db\f\n\2\2\u00db\u00dc\t\t\2\2\u00dc\u00f3\5\30\r\13"+
-    "\u00dd\u00de\f\t\2\2\u00de\u00df\7)\2\2\u00df\u00f3\5\30\r\n\u00e0\u00e1"+
-    "\f\b\2\2\u00e1\u00e2\7*\2\2\u00e2\u00f3\5\30\r\t\u00e3\u00e4\f\7\2\2\u00e4"+
-    "\u00e5\7+\2\2\u00e5\u00f3\5\30\r\b\u00e6\u00e7\f\6\2\2\u00e7\u00e8\7,"+
-    "\2\2\u00e8\u00f3\5\30\r\7\u00e9\u00ea\f\5\2\2\u00ea\u00eb\7-\2\2\u00eb"+
-    "\u00f3\5\30\r\6\u00ec\u00ed\f\4\2\2\u00ed\u00ee\7.\2\2\u00ee\u00ef\5\30"+
-    "\r\2\u00ef\u00f0\7/\2\2\u00f0\u00f1\5\30\r\4\u00f1\u00f3\3\2\2\2\u00f2"+
-    "\u00ce\3\2\2\2\u00f2\u00d1\3\2\2\2\u00f2\u00d4\3\2\2\2\u00f2\u00d7\3\2"+
-    "\2\2\u00f2\u00da\3\2\2\2\u00f2\u00dd\3\2\2\2\u00f2\u00e0\3\2\2\2\u00f2"+
-    "\u00e3\3\2\2\2\u00f2\u00e6\3\2\2\2\u00f2\u00e9\3\2\2\2\u00f2\u00ec\3\2"+
-    "\2\2\u00f3\u00f6\3\2\2\2\u00f4\u00f2\3\2\2\2\u00f4\u00f5\3\2\2\2\u00f5"+
-    "\31\3\2\2\2\u00f6\u00f4\3\2\2\2\u00f7\u00fe\5\34\17\2\u00f8\u00fe\5\36"+
-    "\20\2\u00f9\u00fe\5$\23\2\u00fa\u00fe\5(\25\2\u00fb\u00fe\5,\27\2\u00fc"+
-    "\u00fe\5.\30\2\u00fd\u00f7\3\2\2\2\u00fd\u00f8\3\2\2\2\u00fd\u00f9\3\2"+
-    "\2\2\u00fd\u00fa\3\2\2\2\u00fd\u00fb\3\2\2\2\u00fd\u00fc\3\2\2\2\u00fe"+
-    "\33\3\2\2\2\u00ff\u0106\7\t\2\2\u0100\u0107\5\34\17\2\u0101\u0107\5\36"+
-    "\20\2\u0102\u0107\5$\23\2\u0103\u0107\5(\25\2\u0104\u0107\5,\27\2\u0105"+
-    "\u0107\5.\30\2\u0106\u0100\3\2\2\2\u0106\u0101\3\2\2\2\u0106\u0102\3\2"+
-    "\2\2\u0106\u0103\3\2\2\2\u0106\u0104\3\2\2\2\u0106\u0105\3\2\2\2\u0107"+
-    "\u0108\3\2\2\2\u0108\u010b\7\n\2\2\u0109\u010c\5\"\22\2\u010a\u010c\5"+
-    " \21\2\u010b\u0109\3\2\2\2\u010b\u010a\3\2\2\2\u010b\u010c\3\2\2\2\u010c"+
-    "\35\3\2\2\2\u010d\u010e\7\t\2\2\u010e\u010f\5\20\t\2\u010f\u0116\7\n\2"+
-    "\2\u0110\u0117\5\34\17\2\u0111\u0117\5\36\20\2\u0112\u0117\5$\23\2\u0113"+
-    "\u0117\5(\25\2\u0114\u0117\5,\27\2\u0115\u0117\5.\30\2\u0116\u0110\3\2"+
-    "\2\2\u0116\u0111\3\2\2\2\u0116\u0112\3\2\2\2\u0116\u0113\3\2\2\2\u0116"+
-    "\u0114\3\2\2\2\u0116\u0115\3\2\2\2\u0117\37\3\2\2\2\u0118\u0119\7\7\2"+
-    "\2\u0119\u011a\5\30\r\2\u011a\u011d\7\b\2\2\u011b\u011e\5\"\22\2\u011c"+
-    "\u011e\5 \21\2\u011d\u011b\3\2\2\2\u011d\u011c\3\2\2\2\u011d\u011e\3\2"+
-    "\2\2\u011e!\3\2\2\2\u011f\u0122\7\13\2\2\u0120\u0123\5&\24\2\u0121\u0123"+
-    "\5*\26\2\u0122\u0120\3\2\2\2\u0122\u0121\3\2\2\2\u0123#\3\2\2\2\u0124"+
-    "\u0125\5\24\13\2\u0125\u0126\5\"\22\2\u0126%\3\2\2\2\u0127\u0128\5\26"+
-    "\f\2\u0128\u012b\5\60\31\2\u0129\u012c\5\"\22\2\u012a\u012c\5 \21\2\u012b"+
-    "\u0129\3\2\2\2\u012b\u012a\3\2\2\2\u012b\u012c\3\2\2\2\u012c\'\3\2\2\2"+
-    "\u012d\u0130\5\26\f\2\u012e\u0131\5\"\22\2\u012f\u0131\5 \21\2\u0130\u012e"+
-    "\3\2\2\2\u0130\u012f\3\2\2\2\u0130\u0131\3\2\2\2\u0131)\3\2\2\2\u0132"+
-    "\u0135\5\26\f\2\u0133\u0136\5\"\22\2\u0134\u0136\5 \21\2\u0135\u0133\3"+
-    "\2\2\2\u0135\u0134\3\2\2\2\u0135\u0136\3\2\2\2\u0136+\3\2\2\2\u0137\u0138"+
-    "\7\26\2\2\u0138\u0149\5\24\13\2\u0139\u013c\5\60\31\2\u013a\u013d\5\""+
-    "\22\2\u013b\u013d\5 \21\2\u013c\u013a\3\2\2\2\u013c\u013b\3\2\2\2\u013c"+
-    "\u013d\3\2\2\2\u013d\u014a\3\2\2\2\u013e\u013f\7\7\2\2\u013f\u0140\5\30"+
-    "\r\2\u0140\u0141\7\b\2\2\u0141\u0143\3\2\2\2\u0142\u013e\3\2\2\2\u0143"+
-    "\u0144\3\2\2\2\u0144\u0142\3\2\2\2\u0144\u0145\3\2\2\2\u0145\u0147\3\2"+
-    "\2\2\u0146\u0148\5\"\22\2\u0147\u0146\3\2\2\2\u0147\u0148\3\2\2\2\u0148"+
-    "\u014a\3\2\2\2\u0149\u0139\3\2\2\2\u0149\u0142\3\2\2\2\u014a-\3\2\2\2"+
-    "\u014b\u014e\7C\2\2\u014c\u014f\5\"\22\2\u014d\u014f\5 \21\2\u014e\u014c"+
-    "\3\2\2\2\u014e\u014d\3\2\2\2\u014e\u014f\3\2\2\2\u014f/\3\2\2\2\u0150"+
-    "\u0159\7\t\2\2\u0151\u0156\5\30\r\2\u0152\u0153\7\f\2\2\u0153\u0155\5"+
-    "\30\r\2\u0154\u0152\3\2\2\2\u0155\u0158\3\2\2\2\u0156\u0154\3\2\2\2\u0156"+
-    "\u0157\3\2\2\2\u0157\u015a\3\2\2\2\u0158\u0156\3\2\2\2\u0159\u0151\3\2"+
-    "\2\2\u0159\u015a\3\2\2\2\u015a\u015b\3\2\2\2\u015b\u015c\7\n\2\2\u015c"+
-    "\61\3\2\2\2\u015d\u015e\t\n\2\2\u015e\63\3\2\2\2*\67BJSX\\`eimqvz|\u0082"+
-    "\u0087\u008d\u0097\u009f\u00a5\u00ab\u00cc\u00f2\u00f4\u00fd\u0106\u010b"+
-    "\u0116\u011d\u0122\u012b\u0130\u0135\u013c\u0144\u0147\u0149\u014e\u0156"+
-    "\u0159";
+    "\5\26\u0135\n\26\3\26\3\26\5\26\u0139\n\26\3\27\3\27\3\27\3\27\3\27\5"+
+    "\27\u0140\n\27\3\27\3\27\3\27\3\27\6\27\u0146\n\27\r\27\16\27\u0147\3"+
+    "\27\5\27\u014b\n\27\5\27\u014d\n\27\3\30\3\30\3\30\5\30\u0152\n\30\3\31"+
+    "\3\31\3\31\3\31\7\31\u0158\n\31\f\31\16\31\u015b\13\31\5\31\u015d\n\31"+
+    "\3\31\3\31\3\32\3\32\3\32\2\3\30\33\2\4\6\b\n\f\16\20\22\24\26\30\32\34"+
+    "\36 \"$&(*,.\60\62\2\13\4\2\27\30\34\35\3\2\62=\3\2?B\3\2\31\33\3\2\34"+
+    "\35\3\2\36 \3\2!$\3\2%(\3\2\60\61\u019f\2\65\3\2\2\2\4|\3\2\2\2\6\u0087"+
+    "\3\2\2\2\b\u0089\3\2\2\2\n\u008d\3\2\2\2\f\u008f\3\2\2\2\16\u0091\3\2"+
+    "\2\2\20\u009a\3\2\2\2\22\u00a2\3\2\2\2\24\u00ab\3\2\2\2\26\u00ad\3\2\2"+
+    "\2\30\u00cc\3\2\2\2\32\u00fd\3\2\2\2\34\u00ff\3\2\2\2\36\u010d\3\2\2\2"+
+    " \u0118\3\2\2\2\"\u011f\3\2\2\2$\u0124\3\2\2\2&\u0127\3\2\2\2(\u012d\3"+
+    "\2\2\2*\u0134\3\2\2\2,\u013a\3\2\2\2.\u014e\3\2\2\2\60\u0153\3\2\2\2\62"+
+    "\u0160\3\2\2\2\64\66\5\4\3\2\65\64\3\2\2\2\66\67\3\2\2\2\67\65\3\2\2\2"+
+    "\678\3\2\2\289\3\2\2\29:\7\2\2\3:\3\3\2\2\2;<\7\16\2\2<=\7\t\2\2=>\5\30"+
+    "\r\2>?\7\n\2\2?B\5\6\4\2@A\7\17\2\2AC\5\6\4\2B@\3\2\2\2BC\3\2\2\2C}\3"+
+    "\2\2\2DE\7\20\2\2EF\7\t\2\2FG\5\30\r\2GJ\7\n\2\2HK\5\6\4\2IK\5\b\5\2J"+
+    "H\3\2\2\2JI\3\2\2\2K}\3\2\2\2LM\7\21\2\2MN\5\6\4\2NO\7\20\2\2OP\7\t\2"+
+    "\2PQ\5\30\r\2QS\7\n\2\2RT\7\r\2\2SR\3\2\2\2ST\3\2\2\2T}\3\2\2\2UV\7\22"+
+    "\2\2VX\7\t\2\2WY\5\n\6\2XW\3\2\2\2XY\3\2\2\2YZ\3\2\2\2Z\\\7\r\2\2[]\5"+
+    "\30\r\2\\[\3\2\2\2\\]\3\2\2\2]^\3\2\2\2^`\7\r\2\2_a\5\f\7\2`_\3\2\2\2"+
+    "`a\3\2\2\2ab\3\2\2\2be\7\n\2\2cf\5\6\4\2df\5\b\5\2ec\3\2\2\2ed\3\2\2\2"+
+    "f}\3\2\2\2gi\5\16\b\2hj\7\r\2\2ih\3\2\2\2ij\3\2\2\2j}\3\2\2\2km\7\23\2"+
+    "\2ln\7\r\2\2ml\3\2\2\2mn\3\2\2\2n}\3\2\2\2oq\7\24\2\2pr\7\r\2\2qp\3\2"+
+    "\2\2qr\3\2\2\2r}\3\2\2\2st\7\25\2\2tv\5\30\r\2uw\7\r\2\2vu\3\2\2\2vw\3"+
+    "\2\2\2w}\3\2\2\2xz\5\30\r\2y{\7\r\2\2zy\3\2\2\2z{\3\2\2\2{}\3\2\2\2|;"+
+    "\3\2\2\2|D\3\2\2\2|L\3\2\2\2|U\3\2\2\2|g\3\2\2\2|k\3\2\2\2|o\3\2\2\2|"+
+    "s\3\2\2\2|x\3\2\2\2}\5\3\2\2\2~\u0082\7\5\2\2\177\u0081\5\4\3\2\u0080"+
+    "\177\3\2\2\2\u0081\u0084\3\2\2\2\u0082\u0080\3\2\2\2\u0082\u0083\3\2\2"+
+    "\2\u0083\u0085\3\2\2\2\u0084\u0082\3\2\2\2\u0085\u0088\7\6\2\2\u0086\u0088"+
+    "\5\4\3\2\u0087~\3\2\2\2\u0087\u0086\3\2\2\2\u0088\7\3\2\2\2\u0089\u008a"+
+    "\7\r\2\2\u008a\t\3\2\2\2\u008b\u008e\5\16\b\2\u008c\u008e\5\30\r\2\u008d"+
+    "\u008b\3\2\2\2\u008d\u008c\3\2\2\2\u008e\13\3\2\2\2\u008f\u0090\5\30\r"+
+    "\2\u0090\r\3\2\2\2\u0091\u0092\5\20\t\2\u0092\u0097\5\22\n\2\u0093\u0094"+
+    "\7\f\2\2\u0094\u0096\5\22\n\2\u0095\u0093\3\2\2\2\u0096\u0099\3\2\2\2"+
+    "\u0097\u0095\3\2\2\2\u0097\u0098\3\2\2\2\u0098\17\3\2\2\2\u0099\u0097"+
+    "\3\2\2\2\u009a\u009f\5\24\13\2\u009b\u009c\7\7\2\2\u009c\u009e\7\b\2\2"+
+    "\u009d\u009b\3\2\2\2\u009e\u00a1\3\2\2\2\u009f\u009d\3\2\2\2\u009f\u00a0"+
+    "\3\2\2\2\u00a0\21\3\2\2\2\u00a1\u009f\3\2\2\2\u00a2\u00a5\5\26\f\2\u00a3"+
+    "\u00a4\7\62\2\2\u00a4\u00a6\5\30\r\2\u00a5\u00a3\3\2\2\2\u00a5\u00a6\3"+
+    "\2\2\2\u00a6\23\3\2\2\2\u00a7\u00a8\6\13\2\2\u00a8\u00ac\7H\2\2\u00a9"+
+    "\u00aa\6\13\3\2\u00aa\u00ac\7I\2\2\u00ab\u00a7\3\2\2\2\u00ab\u00a9\3\2"+
+    "\2\2\u00ac\25\3\2\2\2\u00ad\u00ae\6\f\4\2\u00ae\u00af\7H\2\2\u00af\27"+
+    "\3\2\2\2\u00b0\u00b1\b\r\1\2\u00b1\u00b2\t\2\2\2\u00b2\u00cd\5\30\r\20"+
+    "\u00b3\u00b4\7\t\2\2\u00b4\u00b5\5\20\t\2\u00b5\u00b6\7\n\2\2\u00b6\u00b7"+
+    "\5\30\r\17\u00b7\u00cd\3\2\2\2\u00b8\u00b9\5\32\16\2\u00b9\u00ba\t\3\2"+
+    "\2\u00ba\u00bb\5\30\r\3\u00bb\u00cd\3\2\2\2\u00bc\u00bd\7\t\2\2\u00bd"+
+    "\u00be\5\30\r\2\u00be\u00bf\7\n\2\2\u00bf\u00cd\3\2\2\2\u00c0\u00cd\t"+
+    "\4\2\2\u00c1\u00cd\7D\2\2\u00c2\u00cd\7E\2\2\u00c3\u00cd\7F\2\2\u00c4"+
+    "\u00cd\7G\2\2\u00c5\u00cd\5\32\16\2\u00c6\u00c7\5\32\16\2\u00c7\u00c8"+
+    "\5\62\32\2\u00c8\u00cd\3\2\2\2\u00c9\u00ca\5\62\32\2\u00ca\u00cb\5\32"+
+    "\16\2\u00cb\u00cd\3\2\2\2\u00cc\u00b0\3\2\2\2\u00cc\u00b3\3\2\2\2\u00cc"+
+    "\u00b8\3\2\2\2\u00cc\u00bc\3\2\2\2\u00cc\u00c0\3\2\2\2\u00cc\u00c1\3\2"+
+    "\2\2\u00cc\u00c2\3\2\2\2\u00cc\u00c3\3\2\2\2\u00cc\u00c4\3\2\2\2\u00cc"+
+    "\u00c5\3\2\2\2\u00cc\u00c6\3\2\2\2\u00cc\u00c9\3\2\2\2\u00cd\u00f4\3\2"+
+    "\2\2\u00ce\u00cf\f\16\2\2\u00cf\u00d0\t\5\2\2\u00d0\u00f3\5\30\r\17\u00d1"+
+    "\u00d2\f\r\2\2\u00d2\u00d3\t\6\2\2\u00d3\u00f3\5\30\r\16\u00d4\u00d5\f"+
+    "\f\2\2\u00d5\u00d6\t\7\2\2\u00d6\u00f3\5\30\r\r\u00d7\u00d8\f\13\2\2\u00d8"+
+    "\u00d9\t\b\2\2\u00d9\u00f3\5\30\r\f\u00da\u00db\f\n\2\2\u00db\u00dc\t"+
+    "\t\2\2\u00dc\u00f3\5\30\r\13\u00dd\u00de\f\t\2\2\u00de\u00df\7)\2\2\u00df"+
+    "\u00f3\5\30\r\n\u00e0\u00e1\f\b\2\2\u00e1\u00e2\7*\2\2\u00e2\u00f3\5\30"+
+    "\r\t\u00e3\u00e4\f\7\2\2\u00e4\u00e5\7+\2\2\u00e5\u00f3\5\30\r\b\u00e6"+
+    "\u00e7\f\6\2\2\u00e7\u00e8\7,\2\2\u00e8\u00f3\5\30\r\7\u00e9\u00ea\f\5"+
+    "\2\2\u00ea\u00eb\7-\2\2\u00eb\u00f3\5\30\r\6\u00ec\u00ed\f\4\2\2\u00ed"+
+    "\u00ee\7.\2\2\u00ee\u00ef\5\30\r\2\u00ef\u00f0\7/\2\2\u00f0\u00f1\5\30"+
+    "\r\4\u00f1\u00f3\3\2\2\2\u00f2\u00ce\3\2\2\2\u00f2\u00d1\3\2\2\2\u00f2"+
+    "\u00d4\3\2\2\2\u00f2\u00d7\3\2\2\2\u00f2\u00da\3\2\2\2\u00f2\u00dd\3\2"+
+    "\2\2\u00f2\u00e0\3\2\2\2\u00f2\u00e3\3\2\2\2\u00f2\u00e6\3\2\2\2\u00f2"+
+    "\u00e9\3\2\2\2\u00f2\u00ec\3\2\2\2\u00f3\u00f6\3\2\2\2\u00f4\u00f2\3\2"+
+    "\2\2\u00f4\u00f5\3\2\2\2\u00f5\31\3\2\2\2\u00f6\u00f4\3\2\2\2\u00f7\u00fe"+
+    "\5\34\17\2\u00f8\u00fe\5\36\20\2\u00f9\u00fe\5$\23\2\u00fa\u00fe\5(\25"+
+    "\2\u00fb\u00fe\5,\27\2\u00fc\u00fe\5.\30\2\u00fd\u00f7\3\2\2\2\u00fd\u00f8"+
+    "\3\2\2\2\u00fd\u00f9\3\2\2\2\u00fd\u00fa\3\2\2\2\u00fd\u00fb\3\2\2\2\u00fd"+
+    "\u00fc\3\2\2\2\u00fe\33\3\2\2\2\u00ff\u0106\7\t\2\2\u0100\u0107\5\34\17"+
+    "\2\u0101\u0107\5\36\20\2\u0102\u0107\5$\23\2\u0103\u0107\5(\25\2\u0104"+
+    "\u0107\5,\27\2\u0105\u0107\5.\30\2\u0106\u0100\3\2\2\2\u0106\u0101\3\2"+
+    "\2\2\u0106\u0102\3\2\2\2\u0106\u0103\3\2\2\2\u0106\u0104\3\2\2\2\u0106"+
+    "\u0105\3\2\2\2\u0107\u0108\3\2\2\2\u0108\u010b\7\n\2\2\u0109\u010c\5\""+
+    "\22\2\u010a\u010c\5 \21\2\u010b\u0109\3\2\2\2\u010b\u010a\3\2\2\2\u010b"+
+    "\u010c\3\2\2\2\u010c\35\3\2\2\2\u010d\u010e\7\t\2\2\u010e\u010f\5\20\t"+
+    "\2\u010f\u0116\7\n\2\2\u0110\u0117\5\34\17\2\u0111\u0117\5\36\20\2\u0112"+
+    "\u0117\5$\23\2\u0113\u0117\5(\25\2\u0114\u0117\5,\27\2\u0115\u0117\5."+
+    "\30\2\u0116\u0110\3\2\2\2\u0116\u0111\3\2\2\2\u0116\u0112\3\2\2\2\u0116"+
+    "\u0113\3\2\2\2\u0116\u0114\3\2\2\2\u0116\u0115\3\2\2\2\u0117\37\3\2\2"+
+    "\2\u0118\u0119\7\7\2\2\u0119\u011a\5\30\r\2\u011a\u011d\7\b\2\2\u011b"+
+    "\u011e\5\"\22\2\u011c\u011e\5 \21\2\u011d\u011b\3\2\2\2\u011d\u011c\3"+
+    "\2\2\2\u011d\u011e\3\2\2\2\u011e!\3\2\2\2\u011f\u0122\7\13\2\2\u0120\u0123"+
+    "\5&\24\2\u0121\u0123\5*\26\2\u0122\u0120\3\2\2\2\u0122\u0121\3\2\2\2\u0123"+
+    "#\3\2\2\2\u0124\u0125\5\24\13\2\u0125\u0126\5\"\22\2\u0126%\3\2\2\2\u0127"+
+    "\u0128\5\26\f\2\u0128\u012b\5\60\31\2\u0129\u012c\5\"\22\2\u012a\u012c"+
+    "\5 \21\2\u012b\u0129\3\2\2\2\u012b\u012a\3\2\2\2\u012b\u012c\3\2\2\2\u012c"+
+    "\'\3\2\2\2\u012d\u0130\5\26\f\2\u012e\u0131\5\"\22\2\u012f\u0131\5 \21"+
+    "\2\u0130\u012e\3\2\2\2\u0130\u012f\3\2\2\2\u0130\u0131\3\2\2\2\u0131)"+
+    "\3\2\2\2\u0132\u0135\5\26\f\2\u0133\u0135\7A\2\2\u0134\u0132\3\2\2\2\u0134"+
+    "\u0133\3\2\2\2\u0135\u0138\3\2\2\2\u0136\u0139\5\"\22\2\u0137\u0139\5"+
+    " \21\2\u0138\u0136\3\2\2\2\u0138\u0137\3\2\2\2\u0138\u0139\3\2\2\2\u0139"+
+    "+\3\2\2\2\u013a\u013b\7\26\2\2\u013b\u014c\5\24\13\2\u013c\u013f\5\60"+
+    "\31\2\u013d\u0140\5\"\22\2\u013e\u0140\5 \21\2\u013f\u013d\3\2\2\2\u013f"+
+    "\u013e\3\2\2\2\u013f\u0140\3\2\2\2\u0140\u014d\3\2\2\2\u0141\u0142\7\7"+
+    "\2\2\u0142\u0143\5\30\r\2\u0143\u0144\7\b\2\2\u0144\u0146\3\2\2\2\u0145"+
+    "\u0141\3\2\2\2\u0146\u0147\3\2\2\2\u0147\u0145\3\2\2\2\u0147\u0148\3\2"+
+    "\2\2\u0148\u014a\3\2\2\2\u0149\u014b\5\"\22\2\u014a\u0149\3\2\2\2\u014a"+
+    "\u014b\3\2\2\2\u014b\u014d\3\2\2\2\u014c\u013c\3\2\2\2\u014c\u0145\3\2"+
+    "\2\2\u014d-\3\2\2\2\u014e\u0151\7C\2\2\u014f\u0152\5\"\22\2\u0150\u0152"+
+    "\5 \21\2\u0151\u014f\3\2\2\2\u0151\u0150\3\2\2\2\u0151\u0152\3\2\2\2\u0152"+
+    "/\3\2\2\2\u0153\u015c\7\t\2\2\u0154\u0159\5\30\r\2\u0155\u0156\7\f\2\2"+
+    "\u0156\u0158\5\30\r\2\u0157\u0155\3\2\2\2\u0158\u015b\3\2\2\2\u0159\u0157"+
+    "\3\2\2\2\u0159\u015a\3\2\2\2\u015a\u015d\3\2\2\2\u015b\u0159\3\2\2\2\u015c"+
+    "\u0154\3\2\2\2\u015c\u015d\3\2\2\2\u015d\u015e\3\2\2\2\u015e\u015f\7\n"+
+    "\2\2\u015f\61\3\2\2\2\u0160\u0161\t\n\2\2\u0161\63\3\2\2\2+\67BJSX\\`"+
+    "eimqvz|\u0082\u0087\u008d\u0097\u009f\u00a5\u00ab\u00cc\u00f2\u00f4\u00fd"+
+    "\u0106\u010b\u0116\u011d\u0122\u012b\u0130\u0134\u0138\u013f\u0147\u014a"+
+    "\u014c\u0151\u0159\u015c";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/src/main/java/org/elasticsearch/plan/a/PlanAParser.java
+++ b/src/main/java/org/elasticsearch/plan/a/PlanAParser.java
@@ -34,13 +34,13 @@ class PlanAParser extends Parser {
     RULE_afterthought = 5, RULE_declaration = 6, RULE_decltype = 7, RULE_declvar = 8, 
     RULE_type = 9, RULE_id = 10, RULE_expression = 11, RULE_extstart = 12, 
     RULE_extprec = 13, RULE_extcast = 14, RULE_extbrace = 15, RULE_extdot = 16, 
-    RULE_exttype = 17, RULE_extcall = 18, RULE_extmember = 19, RULE_extnew = 20, 
-    RULE_arguments = 21, RULE_increment = 22;
+    RULE_exttype = 17, RULE_extcall = 18, RULE_extvar = 19, RULE_extmember = 20, 
+    RULE_extnew = 21, RULE_extstring = 22, RULE_arguments = 23, RULE_increment = 24;
   public static final String[] ruleNames = {
     "source", "statement", "block", "empty", "initializer", "afterthought", 
     "declaration", "decltype", "declvar", "type", "id", "expression", "extstart", 
-    "extprec", "extcast", "extbrace", "extdot", "exttype", "extcall", "extmember", 
-    "extnew", "arguments", "increment"
+    "extprec", "extcast", "extbrace", "extdot", "exttype", "extcall", "extvar", 
+    "extmember", "extnew", "extstring", "arguments", "increment"
   };
 
   private static final String[] _LITERAL_NAMES = {
@@ -153,7 +153,7 @@ class PlanAParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(47); 
+      setState(51); 
       _errHandler.sync(this);
       _alt = 1;
       do {
@@ -161,7 +161,7 @@ class PlanAParser extends Parser {
         case 1:
           {
           {
-          setState(46);
+          setState(50);
           statement();
           }
           }
@@ -169,11 +169,11 @@ class PlanAParser extends Parser {
         default:
           throw new NoViableAltException(this);
         }
-        setState(49); 
+        setState(53); 
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,0,_ctx);
       } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
-      setState(51);
+      setState(55);
       match(EOF);
       }
     }
@@ -351,29 +351,29 @@ class PlanAParser extends Parser {
     StatementContext _localctx = new StatementContext(_ctx, getState());
     enterRule(_localctx, 2, RULE_statement);
     try {
-      setState(118);
+      setState(122);
       switch ( getInterpreter().adaptivePredict(_input,13,_ctx) ) {
       case 1:
         _localctx = new IfContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(53);
-        match(IF);
-        setState(54);
-        match(LP);
-        setState(55);
-        expression(0);
-        setState(56);
-        match(RP);
         setState(57);
-        block();
+        match(IF);
+        setState(58);
+        match(LP);
+        setState(59);
+        expression(0);
         setState(60);
+        match(RP);
+        setState(61);
+        block();
+        setState(64);
         switch ( getInterpreter().adaptivePredict(_input,1,_ctx) ) {
         case 1:
           {
-          setState(58);
+          setState(62);
           match(ELSE);
-          setState(59);
+          setState(63);
           block();
           }
           break;
@@ -384,25 +384,25 @@ class PlanAParser extends Parser {
         _localctx = new WhileContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(62);
+        setState(66);
         match(WHILE);
-        setState(63);
+        setState(67);
         match(LP);
-        setState(64);
-        expression(0);
-        setState(65);
-        match(RP);
         setState(68);
+        expression(0);
+        setState(69);
+        match(RP);
+        setState(72);
         switch ( getInterpreter().adaptivePredict(_input,2,_ctx) ) {
         case 1:
           {
-          setState(66);
+          setState(70);
           block();
           }
           break;
         case 2:
           {
-          setState(67);
+          setState(71);
           empty();
           }
           break;
@@ -413,23 +413,23 @@ class PlanAParser extends Parser {
         _localctx = new DoContext(_localctx);
         enterOuterAlt(_localctx, 3);
         {
-        setState(70);
-        match(DO);
-        setState(71);
-        block();
-        setState(72);
-        match(WHILE);
-        setState(73);
-        match(LP);
         setState(74);
-        expression(0);
+        match(DO);
         setState(75);
-        match(RP);
+        block();
+        setState(76);
+        match(WHILE);
         setState(77);
+        match(LP);
+        setState(78);
+        expression(0);
+        setState(79);
+        match(RP);
+        setState(81);
         switch ( getInterpreter().adaptivePredict(_input,3,_ctx) ) {
         case 1:
           {
-          setState(76);
+          setState(80);
           match(SEMICOLON);
           }
           break;
@@ -440,54 +440,54 @@ class PlanAParser extends Parser {
         _localctx = new ForContext(_localctx);
         enterOuterAlt(_localctx, 4);
         {
-        setState(79);
+        setState(83);
         match(FOR);
-        setState(80);
+        setState(84);
         match(LP);
-        setState(82);
+        setState(86);
         switch ( getInterpreter().adaptivePredict(_input,4,_ctx) ) {
         case 1:
           {
-          setState(81);
-          initializer();
-          }
-          break;
-        }
-        setState(84);
-        match(SEMICOLON);
-        setState(86);
-        switch ( getInterpreter().adaptivePredict(_input,5,_ctx) ) {
-        case 1:
-          {
           setState(85);
-          expression(0);
+          initializer();
           }
           break;
         }
         setState(88);
         match(SEMICOLON);
         setState(90);
-        switch ( getInterpreter().adaptivePredict(_input,6,_ctx) ) {
+        switch ( getInterpreter().adaptivePredict(_input,5,_ctx) ) {
         case 1:
           {
           setState(89);
-          afterthought();
+          expression(0);
           }
           break;
         }
         setState(92);
-        match(RP);
-        setState(95);
-        switch ( getInterpreter().adaptivePredict(_input,7,_ctx) ) {
+        match(SEMICOLON);
+        setState(94);
+        switch ( getInterpreter().adaptivePredict(_input,6,_ctx) ) {
         case 1:
           {
           setState(93);
+          afterthought();
+          }
+          break;
+        }
+        setState(96);
+        match(RP);
+        setState(99);
+        switch ( getInterpreter().adaptivePredict(_input,7,_ctx) ) {
+        case 1:
+          {
+          setState(97);
           block();
           }
           break;
         case 2:
           {
-          setState(94);
+          setState(98);
           empty();
           }
           break;
@@ -498,13 +498,13 @@ class PlanAParser extends Parser {
         _localctx = new DeclContext(_localctx);
         enterOuterAlt(_localctx, 5);
         {
-        setState(97);
+        setState(101);
         declaration();
-        setState(99);
+        setState(103);
         switch ( getInterpreter().adaptivePredict(_input,8,_ctx) ) {
         case 1:
           {
-          setState(98);
+          setState(102);
           match(SEMICOLON);
           }
           break;
@@ -515,13 +515,13 @@ class PlanAParser extends Parser {
         _localctx = new ContinueContext(_localctx);
         enterOuterAlt(_localctx, 6);
         {
-        setState(101);
+        setState(105);
         match(CONTINUE);
-        setState(103);
+        setState(107);
         switch ( getInterpreter().adaptivePredict(_input,9,_ctx) ) {
         case 1:
           {
-          setState(102);
+          setState(106);
           match(SEMICOLON);
           }
           break;
@@ -532,13 +532,13 @@ class PlanAParser extends Parser {
         _localctx = new BreakContext(_localctx);
         enterOuterAlt(_localctx, 7);
         {
-        setState(105);
+        setState(109);
         match(BREAK);
-        setState(107);
+        setState(111);
         switch ( getInterpreter().adaptivePredict(_input,10,_ctx) ) {
         case 1:
           {
-          setState(106);
+          setState(110);
           match(SEMICOLON);
           }
           break;
@@ -549,15 +549,15 @@ class PlanAParser extends Parser {
         _localctx = new ReturnContext(_localctx);
         enterOuterAlt(_localctx, 8);
         {
-        setState(109);
+        setState(113);
         match(RETURN);
-        setState(110);
+        setState(114);
         expression(0);
-        setState(112);
+        setState(116);
         switch ( getInterpreter().adaptivePredict(_input,11,_ctx) ) {
         case 1:
           {
-          setState(111);
+          setState(115);
           match(SEMICOLON);
           }
           break;
@@ -568,13 +568,13 @@ class PlanAParser extends Parser {
         _localctx = new ExprContext(_localctx);
         enterOuterAlt(_localctx, 9);
         {
-        setState(114);
+        setState(118);
         expression(0);
-        setState(116);
+        setState(120);
         switch ( getInterpreter().adaptivePredict(_input,12,_ctx) ) {
         case 1:
           {
-          setState(115);
+          setState(119);
           match(SEMICOLON);
           }
           break;
@@ -638,31 +638,31 @@ class PlanAParser extends Parser {
     enterRule(_localctx, 4, RULE_block);
     try {
       int _alt;
-      setState(129);
+      setState(133);
       switch ( getInterpreter().adaptivePredict(_input,15,_ctx) ) {
       case 1:
         _localctx = new MultipleContext(_localctx);
         enterOuterAlt(_localctx, 1);
         {
-        setState(120);
-        match(LBRACK);
         setState(124);
+        match(LBRACK);
+        setState(128);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,14,_ctx);
         while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
           if ( _alt==1 ) {
             {
             {
-            setState(121);
+            setState(125);
             statement();
             }
             } 
           }
-          setState(126);
+          setState(130);
           _errHandler.sync(this);
           _alt = getInterpreter().adaptivePredict(_input,14,_ctx);
         }
-        setState(127);
+        setState(131);
         match(RBRACK);
         }
         break;
@@ -670,7 +670,7 @@ class PlanAParser extends Parser {
         _localctx = new SingleContext(_localctx);
         enterOuterAlt(_localctx, 2);
         {
-        setState(128);
+        setState(132);
         statement();
         }
         break;
@@ -706,7 +706,7 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(131);
+      setState(135);
       match(SEMICOLON);
       }
     }
@@ -743,19 +743,19 @@ class PlanAParser extends Parser {
     InitializerContext _localctx = new InitializerContext(_ctx, getState());
     enterRule(_localctx, 8, RULE_initializer);
     try {
-      setState(135);
+      setState(139);
       switch ( getInterpreter().adaptivePredict(_input,16,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(133);
+        setState(137);
         declaration();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(134);
+        setState(138);
         expression(0);
         }
         break;
@@ -793,7 +793,7 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(137);
+      setState(141);
       expression(0);
       }
     }
@@ -840,25 +840,25 @@ class PlanAParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(139);
+      setState(143);
       decltype();
-      setState(140);
+      setState(144);
       declvar();
-      setState(145);
+      setState(149);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,17,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
           {
-          setState(141);
+          setState(145);
           match(COMMA);
-          setState(142);
+          setState(146);
           declvar();
           }
           } 
         }
-        setState(147);
+        setState(151);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,17,_ctx);
       }
@@ -905,23 +905,23 @@ class PlanAParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(148);
+      setState(152);
       type();
-      setState(153);
+      setState(157);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,18,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
         if ( _alt==1 ) {
           {
           {
-          setState(149);
+          setState(153);
           match(LBRACE);
-          setState(150);
+          setState(154);
           match(RBRACE);
           }
           } 
         }
-        setState(155);
+        setState(159);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,18,_ctx);
       }
@@ -963,15 +963,15 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(156);
+      setState(160);
       id();
-      setState(159);
+      setState(163);
       switch ( getInterpreter().adaptivePredict(_input,19,_ctx) ) {
       case 1:
         {
-        setState(157);
+        setState(161);
         match(ASSIGN);
-        setState(158);
+        setState(162);
         expression(0);
         }
         break;
@@ -1007,23 +1007,23 @@ class PlanAParser extends Parser {
     TypeContext _localctx = new TypeContext(_ctx, getState());
     enterRule(_localctx, 18, RULE_type);
     try {
-      setState(165);
+      setState(169);
       switch ( getInterpreter().adaptivePredict(_input,20,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(161);
+        setState(165);
         if (!(isType())) throw new FailedPredicateException(this, "isType()");
-        setState(162);
+        setState(166);
         match(ID);
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(163);
+        setState(167);
         if (!(isType())) throw new FailedPredicateException(this, "isType()");
-        setState(164);
+        setState(168);
         match(GENERIC);
         }
         break;
@@ -1059,9 +1059,9 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(167);
+      setState(171);
       if (!(!isType())) throw new FailedPredicateException(this, "!isType()");
-      setState(168);
+      setState(172);
       match(ID);
       }
     }
@@ -1106,15 +1106,6 @@ class PlanAParser extends Parser {
     @Override
     public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
       if ( visitor instanceof PlanAVisitor ) return ((PlanAVisitor<? extends T>)visitor).visitComp(this);
-      else return visitor.visitChildren(this);
-    }
-  }
-  public static class StringContext extends ExpressionContext {
-    public TerminalNode STRING() { return getToken(PlanAParser.STRING, 0); }
-    public StringContext(ExpressionContext ctx) { copyFrom(ctx); }
-    @Override
-    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
-      if ( visitor instanceof PlanAVisitor ) return ((PlanAVisitor<? extends T>)visitor).visitString(this);
       else return visitor.visitChildren(this);
     }
   }
@@ -1349,7 +1340,7 @@ class PlanAParser extends Parser {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(199);
+      setState(202);
       switch ( getInterpreter().adaptivePredict(_input,21,_ctx) ) {
       case 1:
         {
@@ -1357,14 +1348,14 @@ class PlanAParser extends Parser {
         _ctx = _localctx;
         _prevctx = _localctx;
 
-        setState(171);
+        setState(175);
         _la = _input.LA(1);
         if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << BOOLNOT) | (1L << BWNOT) | (1L << ADD) | (1L << SUB))) != 0)) ) {
         _errHandler.recoverInline(this);
         } else {
           consume();
         }
-        setState(172);
+        setState(176);
         expression(14);
         }
         break;
@@ -1373,13 +1364,13 @@ class PlanAParser extends Parser {
         _localctx = new CastContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(173);
+        setState(177);
         match(LP);
-        setState(174);
+        setState(178);
         decltype();
-        setState(175);
+        setState(179);
         match(RP);
-        setState(176);
+        setState(180);
         expression(13);
         }
         break;
@@ -1388,16 +1379,16 @@ class PlanAParser extends Parser {
         _localctx = new AssignmentContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(178);
+        setState(182);
         extstart();
-        setState(179);
+        setState(183);
         _la = _input.LA(1);
         if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << ASSIGN) | (1L << AADD) | (1L << ASUB) | (1L << AMUL) | (1L << ADIV) | (1L << AREM) | (1L << AAND) | (1L << AXOR) | (1L << AOR) | (1L << ALSH) | (1L << ARSH) | (1L << AUSH))) != 0)) ) {
         _errHandler.recoverInline(this);
         } else {
           consume();
         }
-        setState(180);
+        setState(184);
         expression(1);
         }
         break;
@@ -1406,11 +1397,11 @@ class PlanAParser extends Parser {
         _localctx = new PrecedenceContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(182);
+        setState(186);
         match(LP);
-        setState(183);
+        setState(187);
         expression(0);
-        setState(184);
+        setState(188);
         match(RP);
         }
         break;
@@ -1419,7 +1410,7 @@ class PlanAParser extends Parser {
         _localctx = new NumericContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(186);
+        setState(190);
         _la = _input.LA(1);
         if ( !(((((_la - 61)) & ~0x3f) == 0 && ((1L << (_la - 61)) & ((1L << (OCTAL - 61)) | (1L << (HEX - 61)) | (1L << (INTEGER - 61)) | (1L << (DECIMAL - 61)))) != 0)) ) {
         _errHandler.recoverInline(this);
@@ -1430,83 +1421,74 @@ class PlanAParser extends Parser {
         break;
       case 6:
         {
-        _localctx = new StringContext(_localctx);
+        _localctx = new CharContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(187);
-        match(STRING);
+        setState(191);
+        match(CHAR);
         }
         break;
       case 7:
         {
-        _localctx = new CharContext(_localctx);
+        _localctx = new TrueContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(188);
-        match(CHAR);
+        setState(192);
+        match(TRUE);
         }
         break;
       case 8:
         {
-        _localctx = new TrueContext(_localctx);
+        _localctx = new FalseContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(189);
-        match(TRUE);
+        setState(193);
+        match(FALSE);
         }
         break;
       case 9:
         {
-        _localctx = new FalseContext(_localctx);
+        _localctx = new NullContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(190);
-        match(FALSE);
+        setState(194);
+        match(NULL);
         }
         break;
       case 10:
         {
-        _localctx = new NullContext(_localctx);
+        _localctx = new ExternalContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(191);
-        match(NULL);
+        setState(195);
+        extstart();
         }
         break;
       case 11:
         {
-        _localctx = new ExternalContext(_localctx);
+        _localctx = new PostincContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(192);
+        setState(196);
         extstart();
+        setState(197);
+        increment();
         }
         break;
       case 12:
         {
-        _localctx = new PostincContext(_localctx);
-        _ctx = _localctx;
-        _prevctx = _localctx;
-        setState(193);
-        extstart();
-        setState(194);
-        increment();
-        }
-        break;
-      case 13:
-        {
         _localctx = new PreincContext(_localctx);
         _ctx = _localctx;
         _prevctx = _localctx;
-        setState(196);
+        setState(199);
         increment();
-        setState(197);
+        setState(200);
         extstart();
         }
         break;
       }
       _ctx.stop = _input.LT(-1);
-      setState(239);
+      setState(242);
       _errHandler.sync(this);
       _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
       while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER ) {
@@ -1514,22 +1496,22 @@ class PlanAParser extends Parser {
           if ( _parseListeners!=null ) triggerExitRuleEvent();
           _prevctx = _localctx;
           {
-          setState(237);
+          setState(240);
           switch ( getInterpreter().adaptivePredict(_input,22,_ctx) ) {
           case 1:
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(201);
+            setState(204);
             if (!(precpred(_ctx, 12))) throw new FailedPredicateException(this, "precpred(_ctx, 12)");
-            setState(202);
+            setState(205);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << MUL) | (1L << DIV) | (1L << REM))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(203);
+            setState(206);
             expression(13);
             }
             break;
@@ -1537,16 +1519,16 @@ class PlanAParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(204);
+            setState(207);
             if (!(precpred(_ctx, 11))) throw new FailedPredicateException(this, "precpred(_ctx, 11)");
-            setState(205);
+            setState(208);
             _la = _input.LA(1);
             if ( !(_la==ADD || _la==SUB) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(206);
+            setState(209);
             expression(12);
             }
             break;
@@ -1554,16 +1536,16 @@ class PlanAParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(207);
+            setState(210);
             if (!(precpred(_ctx, 10))) throw new FailedPredicateException(this, "precpred(_ctx, 10)");
-            setState(208);
+            setState(211);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LSH) | (1L << RSH) | (1L << USH))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(209);
+            setState(212);
             expression(11);
             }
             break;
@@ -1571,16 +1553,16 @@ class PlanAParser extends Parser {
             {
             _localctx = new CompContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(210);
+            setState(213);
             if (!(precpred(_ctx, 9))) throw new FailedPredicateException(this, "precpred(_ctx, 9)");
-            setState(211);
+            setState(214);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << LT) | (1L << LTE) | (1L << GT) | (1L << GTE))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(212);
+            setState(215);
             expression(10);
             }
             break;
@@ -1588,16 +1570,16 @@ class PlanAParser extends Parser {
             {
             _localctx = new CompContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(213);
+            setState(216);
             if (!(precpred(_ctx, 8))) throw new FailedPredicateException(this, "precpred(_ctx, 8)");
-            setState(214);
+            setState(217);
             _la = _input.LA(1);
             if ( !((((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << EQ) | (1L << EQR) | (1L << NE) | (1L << NER))) != 0)) ) {
             _errHandler.recoverInline(this);
             } else {
               consume();
             }
-            setState(215);
+            setState(218);
             expression(9);
             }
             break;
@@ -1605,11 +1587,11 @@ class PlanAParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(216);
+            setState(219);
             if (!(precpred(_ctx, 7))) throw new FailedPredicateException(this, "precpred(_ctx, 7)");
-            setState(217);
+            setState(220);
             match(BWAND);
-            setState(218);
+            setState(221);
             expression(8);
             }
             break;
@@ -1617,11 +1599,11 @@ class PlanAParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(219);
+            setState(222);
             if (!(precpred(_ctx, 6))) throw new FailedPredicateException(this, "precpred(_ctx, 6)");
-            setState(220);
+            setState(223);
             match(BWXOR);
-            setState(221);
+            setState(224);
             expression(7);
             }
             break;
@@ -1629,11 +1611,11 @@ class PlanAParser extends Parser {
             {
             _localctx = new BinaryContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(222);
+            setState(225);
             if (!(precpred(_ctx, 5))) throw new FailedPredicateException(this, "precpred(_ctx, 5)");
-            setState(223);
+            setState(226);
             match(BWOR);
-            setState(224);
+            setState(227);
             expression(6);
             }
             break;
@@ -1641,11 +1623,11 @@ class PlanAParser extends Parser {
             {
             _localctx = new BoolContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(225);
+            setState(228);
             if (!(precpred(_ctx, 4))) throw new FailedPredicateException(this, "precpred(_ctx, 4)");
-            setState(226);
+            setState(229);
             match(BOOLAND);
-            setState(227);
+            setState(230);
             expression(5);
             }
             break;
@@ -1653,11 +1635,11 @@ class PlanAParser extends Parser {
             {
             _localctx = new BoolContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(228);
+            setState(231);
             if (!(precpred(_ctx, 3))) throw new FailedPredicateException(this, "precpred(_ctx, 3)");
-            setState(229);
+            setState(232);
             match(BOOLOR);
-            setState(230);
+            setState(233);
             expression(4);
             }
             break;
@@ -1665,22 +1647,22 @@ class PlanAParser extends Parser {
             {
             _localctx = new ConditionalContext(new ExpressionContext(_parentctx, _parentState));
             pushNewRecursionContext(_localctx, _startState, RULE_expression);
-            setState(231);
-            if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
-            setState(232);
-            match(COND);
-            setState(233);
-            expression(0);
             setState(234);
-            match(COLON);
+            if (!(precpred(_ctx, 2))) throw new FailedPredicateException(this, "precpred(_ctx, 2)");
             setState(235);
+            match(COND);
+            setState(236);
+            expression(0);
+            setState(237);
+            match(COLON);
+            setState(238);
             expression(2);
             }
             break;
           }
           } 
         }
-        setState(241);
+        setState(244);
         _errHandler.sync(this);
         _alt = getInterpreter().adaptivePredict(_input,23,_ctx);
       }
@@ -1707,11 +1689,14 @@ class PlanAParser extends Parser {
     public ExttypeContext exttype() {
       return getRuleContext(ExttypeContext.class,0);
     }
-    public ExtmemberContext extmember() {
-      return getRuleContext(ExtmemberContext.class,0);
+    public ExtvarContext extvar() {
+      return getRuleContext(ExtvarContext.class,0);
     }
     public ExtnewContext extnew() {
       return getRuleContext(ExtnewContext.class,0);
+    }
+    public ExtstringContext extstring() {
+      return getRuleContext(ExtstringContext.class,0);
     }
     public ExtstartContext(ParserRuleContext parent, int invokingState) {
       super(parent, invokingState);
@@ -1728,41 +1713,48 @@ class PlanAParser extends Parser {
     ExtstartContext _localctx = new ExtstartContext(_ctx, getState());
     enterRule(_localctx, 24, RULE_extstart);
     try {
-      setState(247);
+      setState(251);
       switch ( getInterpreter().adaptivePredict(_input,24,_ctx) ) {
       case 1:
         enterOuterAlt(_localctx, 1);
         {
-        setState(242);
+        setState(245);
         extprec();
         }
         break;
       case 2:
         enterOuterAlt(_localctx, 2);
         {
-        setState(243);
+        setState(246);
         extcast();
         }
         break;
       case 3:
         enterOuterAlt(_localctx, 3);
         {
-        setState(244);
+        setState(247);
         exttype();
         }
         break;
       case 4:
         enterOuterAlt(_localctx, 4);
         {
-        setState(245);
-        extmember();
+        setState(248);
+        extvar();
         }
         break;
       case 5:
         enterOuterAlt(_localctx, 5);
         {
-        setState(246);
+        setState(249);
         extnew();
+        }
+        break;
+      case 6:
+        enterOuterAlt(_localctx, 6);
+        {
+        setState(250);
+        extstring();
         }
         break;
       }
@@ -1790,11 +1782,14 @@ class PlanAParser extends Parser {
     public ExttypeContext exttype() {
       return getRuleContext(ExttypeContext.class,0);
     }
-    public ExtmemberContext extmember() {
-      return getRuleContext(ExtmemberContext.class,0);
+    public ExtvarContext extvar() {
+      return getRuleContext(ExtvarContext.class,0);
     }
     public ExtnewContext extnew() {
       return getRuleContext(ExtnewContext.class,0);
+    }
+    public ExtstringContext extstring() {
+      return getRuleContext(ExtstringContext.class,0);
     }
     public ExtdotContext extdot() {
       return getRuleContext(ExtdotContext.class,0);
@@ -1819,54 +1814,60 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(249);
+      setState(253);
       match(LP);
-      setState(255);
+      setState(260);
       switch ( getInterpreter().adaptivePredict(_input,25,_ctx) ) {
       case 1:
         {
-        setState(250);
+        setState(254);
         extprec();
         }
         break;
       case 2:
         {
-        setState(251);
+        setState(255);
         extcast();
         }
         break;
       case 3:
         {
-        setState(252);
+        setState(256);
         exttype();
         }
         break;
       case 4:
         {
-        setState(253);
-        extmember();
+        setState(257);
+        extvar();
         }
         break;
       case 5:
         {
-        setState(254);
+        setState(258);
         extnew();
         }
         break;
+      case 6:
+        {
+        setState(259);
+        extstring();
+        }
+        break;
       }
-      setState(257);
+      setState(262);
       match(RP);
-      setState(260);
+      setState(265);
       switch ( getInterpreter().adaptivePredict(_input,26,_ctx) ) {
       case 1:
         {
-        setState(258);
+        setState(263);
         extdot();
         }
         break;
       case 2:
         {
-        setState(259);
+        setState(264);
         extbrace();
         }
         break;
@@ -1899,11 +1900,14 @@ class PlanAParser extends Parser {
     public ExttypeContext exttype() {
       return getRuleContext(ExttypeContext.class,0);
     }
-    public ExtmemberContext extmember() {
-      return getRuleContext(ExtmemberContext.class,0);
+    public ExtvarContext extvar() {
+      return getRuleContext(ExtvarContext.class,0);
     }
     public ExtnewContext extnew() {
       return getRuleContext(ExtnewContext.class,0);
+    }
+    public ExtstringContext extstring() {
+      return getRuleContext(ExtstringContext.class,0);
     }
     public ExtcastContext(ParserRuleContext parent, int invokingState) {
       super(parent, invokingState);
@@ -1922,42 +1926,48 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(262);
+      setState(267);
       match(LP);
-      setState(263);
+      setState(268);
       decltype();
-      setState(264);
+      setState(269);
       match(RP);
-      setState(270);
+      setState(276);
       switch ( getInterpreter().adaptivePredict(_input,27,_ctx) ) {
       case 1:
         {
-        setState(265);
+        setState(270);
         extprec();
         }
         break;
       case 2:
         {
-        setState(266);
+        setState(271);
         extcast();
         }
         break;
       case 3:
         {
-        setState(267);
+        setState(272);
         exttype();
         }
         break;
       case 4:
         {
-        setState(268);
-        extmember();
+        setState(273);
+        extvar();
         }
         break;
       case 5:
         {
-        setState(269);
+        setState(274);
         extnew();
+        }
+        break;
+      case 6:
+        {
+        setState(275);
+        extstring();
         }
         break;
       }
@@ -2003,23 +2013,23 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(272);
+      setState(278);
       match(LBRACE);
-      setState(273);
+      setState(279);
       expression(0);
-      setState(274);
+      setState(280);
       match(RBRACE);
-      setState(277);
+      setState(283);
       switch ( getInterpreter().adaptivePredict(_input,28,_ctx) ) {
       case 1:
         {
-        setState(275);
+        setState(281);
         extdot();
         }
         break;
       case 2:
         {
-        setState(276);
+        setState(282);
         extbrace();
         }
         break;
@@ -2062,19 +2072,19 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(279);
+      setState(285);
       match(DOT);
-      setState(282);
+      setState(288);
       switch ( getInterpreter().adaptivePredict(_input,29,_ctx) ) {
       case 1:
         {
-        setState(280);
+        setState(286);
         extcall();
         }
         break;
       case 2:
         {
-        setState(281);
+        setState(287);
         extmember();
         }
         break;
@@ -2116,9 +2126,9 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(284);
+      setState(290);
       type();
-      setState(285);
+      setState(291);
       extdot();
       }
     }
@@ -2163,21 +2173,78 @@ class PlanAParser extends Parser {
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(287);
+      setState(293);
       id();
-      setState(288);
+      setState(294);
       arguments();
-      setState(291);
+      setState(297);
       switch ( getInterpreter().adaptivePredict(_input,30,_ctx) ) {
       case 1:
         {
-        setState(289);
+        setState(295);
         extdot();
         }
         break;
       case 2:
         {
-        setState(290);
+        setState(296);
+        extbrace();
+        }
+        break;
+      }
+      }
+    }
+    catch (RecognitionException re) {
+      _localctx.exception = re;
+      _errHandler.reportError(this, re);
+      _errHandler.recover(this, re);
+    }
+    finally {
+      exitRule();
+    }
+    return _localctx;
+  }
+
+  public static class ExtvarContext extends ParserRuleContext {
+    public IdContext id() {
+      return getRuleContext(IdContext.class,0);
+    }
+    public ExtdotContext extdot() {
+      return getRuleContext(ExtdotContext.class,0);
+    }
+    public ExtbraceContext extbrace() {
+      return getRuleContext(ExtbraceContext.class,0);
+    }
+    public ExtvarContext(ParserRuleContext parent, int invokingState) {
+      super(parent, invokingState);
+    }
+    @Override public int getRuleIndex() { return RULE_extvar; }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PlanAVisitor ) return ((PlanAVisitor<? extends T>)visitor).visitExtvar(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+
+  public final ExtvarContext extvar() throws RecognitionException {
+    ExtvarContext _localctx = new ExtvarContext(_ctx, getState());
+    enterRule(_localctx, 38, RULE_extvar);
+    try {
+      enterOuterAlt(_localctx, 1);
+      {
+      setState(299);
+      id();
+      setState(302);
+      switch ( getInterpreter().adaptivePredict(_input,31,_ctx) ) {
+      case 1:
+        {
+        setState(300);
+        extdot();
+        }
+        break;
+      case 2:
+        {
+        setState(301);
         extbrace();
         }
         break;
@@ -2218,23 +2285,23 @@ class PlanAParser extends Parser {
 
   public final ExtmemberContext extmember() throws RecognitionException {
     ExtmemberContext _localctx = new ExtmemberContext(_ctx, getState());
-    enterRule(_localctx, 38, RULE_extmember);
+    enterRule(_localctx, 40, RULE_extmember);
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(293);
+      setState(304);
       id();
-      setState(296);
-      switch ( getInterpreter().adaptivePredict(_input,31,_ctx) ) {
+      setState(307);
+      switch ( getInterpreter().adaptivePredict(_input,32,_ctx) ) {
       case 1:
         {
-        setState(294);
+        setState(305);
         extdot();
         }
         break;
       case 2:
         {
-        setState(295);
+        setState(306);
         extbrace();
         }
         break;
@@ -2293,33 +2360,33 @@ class PlanAParser extends Parser {
 
   public final ExtnewContext extnew() throws RecognitionException {
     ExtnewContext _localctx = new ExtnewContext(_ctx, getState());
-    enterRule(_localctx, 40, RULE_extnew);
+    enterRule(_localctx, 42, RULE_extnew);
     try {
       int _alt;
       enterOuterAlt(_localctx, 1);
       {
-      setState(298);
+      setState(309);
       match(NEW);
-      setState(299);
+      setState(310);
       type();
-      setState(316);
+      setState(327);
       switch (_input.LA(1)) {
       case LP:
         {
         {
-        setState(300);
+        setState(311);
         arguments();
-        setState(303);
-        switch ( getInterpreter().adaptivePredict(_input,32,_ctx) ) {
+        setState(314);
+        switch ( getInterpreter().adaptivePredict(_input,33,_ctx) ) {
         case 1:
           {
-          setState(301);
+          setState(312);
           extdot();
           }
           break;
         case 2:
           {
-          setState(302);
+          setState(313);
           extbrace();
           }
           break;
@@ -2330,7 +2397,7 @@ class PlanAParser extends Parser {
       case LBRACE:
         {
         {
-        setState(309); 
+        setState(320); 
         _errHandler.sync(this);
         _alt = 1;
         do {
@@ -2338,11 +2405,11 @@ class PlanAParser extends Parser {
           case 1:
             {
             {
-            setState(305);
+            setState(316);
             match(LBRACE);
-            setState(306);
+            setState(317);
             expression(0);
-            setState(307);
+            setState(318);
             match(RBRACE);
             }
             }
@@ -2350,15 +2417,15 @@ class PlanAParser extends Parser {
           default:
             throw new NoViableAltException(this);
           }
-          setState(311); 
+          setState(322); 
           _errHandler.sync(this);
-          _alt = getInterpreter().adaptivePredict(_input,33,_ctx);
+          _alt = getInterpreter().adaptivePredict(_input,34,_ctx);
         } while ( _alt!=2 && _alt!=org.antlr.v4.runtime.atn.ATN.INVALID_ALT_NUMBER );
-        setState(314);
-        switch ( getInterpreter().adaptivePredict(_input,34,_ctx) ) {
+        setState(325);
+        switch ( getInterpreter().adaptivePredict(_input,35,_ctx) ) {
         case 1:
           {
-          setState(313);
+          setState(324);
           extdot();
           }
           break;
@@ -2368,6 +2435,61 @@ class PlanAParser extends Parser {
         break;
       default:
         throw new NoViableAltException(this);
+      }
+      }
+    }
+    catch (RecognitionException re) {
+      _localctx.exception = re;
+      _errHandler.reportError(this, re);
+      _errHandler.recover(this, re);
+    }
+    finally {
+      exitRule();
+    }
+    return _localctx;
+  }
+
+  public static class ExtstringContext extends ParserRuleContext {
+    public TerminalNode STRING() { return getToken(PlanAParser.STRING, 0); }
+    public ExtdotContext extdot() {
+      return getRuleContext(ExtdotContext.class,0);
+    }
+    public ExtbraceContext extbrace() {
+      return getRuleContext(ExtbraceContext.class,0);
+    }
+    public ExtstringContext(ParserRuleContext parent, int invokingState) {
+      super(parent, invokingState);
+    }
+    @Override public int getRuleIndex() { return RULE_extstring; }
+    @Override
+    public <T> T accept(ParseTreeVisitor<? extends T> visitor) {
+      if ( visitor instanceof PlanAVisitor ) return ((PlanAVisitor<? extends T>)visitor).visitExtstring(this);
+      else return visitor.visitChildren(this);
+    }
+  }
+
+  public final ExtstringContext extstring() throws RecognitionException {
+    ExtstringContext _localctx = new ExtstringContext(_ctx, getState());
+    enterRule(_localctx, 44, RULE_extstring);
+    try {
+      enterOuterAlt(_localctx, 1);
+      {
+      setState(329);
+      match(STRING);
+      setState(332);
+      switch ( getInterpreter().adaptivePredict(_input,37,_ctx) ) {
+      case 1:
+        {
+        setState(330);
+        extdot();
+        }
+        break;
+      case 2:
+        {
+        setState(331);
+        extbrace();
+        }
+        break;
       }
       }
     }
@@ -2408,40 +2530,40 @@ class PlanAParser extends Parser {
 
   public final ArgumentsContext arguments() throws RecognitionException {
     ArgumentsContext _localctx = new ArgumentsContext(_ctx, getState());
-    enterRule(_localctx, 42, RULE_arguments);
+    enterRule(_localctx, 46, RULE_arguments);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
       {
-      setState(318);
+      setState(334);
       match(LP);
-      setState(327);
-      switch ( getInterpreter().adaptivePredict(_input,37,_ctx) ) {
+      setState(343);
+      switch ( getInterpreter().adaptivePredict(_input,39,_ctx) ) {
       case 1:
         {
-        setState(319);
+        setState(335);
         expression(0);
-        setState(324);
+        setState(340);
         _errHandler.sync(this);
         _la = _input.LA(1);
         while (_la==COMMA) {
           {
           {
-          setState(320);
+          setState(336);
           match(COMMA);
-          setState(321);
+          setState(337);
           expression(0);
           }
           }
-          setState(326);
+          setState(342);
           _errHandler.sync(this);
           _la = _input.LA(1);
         }
         }
         break;
       }
-      setState(329);
+      setState(345);
       match(RP);
       }
       }
@@ -2473,12 +2595,12 @@ class PlanAParser extends Parser {
 
   public final IncrementContext increment() throws RecognitionException {
     IncrementContext _localctx = new IncrementContext(_ctx, getState());
-    enterRule(_localctx, 44, RULE_increment);
+    enterRule(_localctx, 48, RULE_increment);
     int _la;
     try {
       enterOuterAlt(_localctx, 1);
       {
-      setState(331);
+      setState(347);
       _la = _input.LA(1);
       if ( !(_la==INCR || _la==DECR) ) {
       _errHandler.recoverInline(this);
@@ -2554,131 +2676,139 @@ class PlanAParser extends Parser {
   }
 
   public static final String _serializedATN =
-    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3I\u0150\4\2\t\2\4"+
+    "\3\u0430\ud6d1\u8206\uad2d\u4417\uaef1\u8d80\uaadd\3I\u0160\4\2\t\2\4"+
     "\3\t\3\4\4\t\4\4\5\t\5\4\6\t\6\4\7\t\7\4\b\t\b\4\t\t\t\4\n\t\n\4\13\t"+
     "\13\4\f\t\f\4\r\t\r\4\16\t\16\4\17\t\17\4\20\t\20\4\21\t\21\4\22\t\22"+
-    "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\3\2\6\2\62"+
-    "\n\2\r\2\16\2\63\3\2\3\2\3\3\3\3\3\3\3\3\3\3\3\3\3\3\5\3?\n\3\3\3\3\3"+
-    "\3\3\3\3\3\3\3\3\5\3G\n\3\3\3\3\3\3\3\3\3\3\3\3\3\3\3\5\3P\n\3\3\3\3\3"+
-    "\3\3\5\3U\n\3\3\3\3\3\5\3Y\n\3\3\3\3\3\5\3]\n\3\3\3\3\3\3\3\5\3b\n\3\3"+
-    "\3\3\3\5\3f\n\3\3\3\3\3\5\3j\n\3\3\3\3\3\5\3n\n\3\3\3\3\3\3\3\5\3s\n\3"+
-    "\3\3\3\3\5\3w\n\3\5\3y\n\3\3\4\3\4\7\4}\n\4\f\4\16\4\u0080\13\4\3\4\3"+
-    "\4\5\4\u0084\n\4\3\5\3\5\3\6\3\6\5\6\u008a\n\6\3\7\3\7\3\b\3\b\3\b\3\b"+
-    "\7\b\u0092\n\b\f\b\16\b\u0095\13\b\3\t\3\t\3\t\7\t\u009a\n\t\f\t\16\t"+
-    "\u009d\13\t\3\n\3\n\3\n\5\n\u00a2\n\n\3\13\3\13\3\13\3\13\5\13\u00a8\n"+
-    "\13\3\f\3\f\3\f\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3"+
-    "\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\5\r\u00ca"+
-    "\n\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3"+
+    "\4\23\t\23\4\24\t\24\4\25\t\25\4\26\t\26\4\27\t\27\4\30\t\30\4\31\t\31"+
+    "\4\32\t\32\3\2\6\2\66\n\2\r\2\16\2\67\3\2\3\2\3\3\3\3\3\3\3\3\3\3\3\3"+
+    "\3\3\5\3C\n\3\3\3\3\3\3\3\3\3\3\3\3\3\5\3K\n\3\3\3\3\3\3\3\3\3\3\3\3\3"+
+    "\3\3\5\3T\n\3\3\3\3\3\3\3\5\3Y\n\3\3\3\3\3\5\3]\n\3\3\3\3\3\5\3a\n\3\3"+
+    "\3\3\3\3\3\5\3f\n\3\3\3\3\3\5\3j\n\3\3\3\3\3\5\3n\n\3\3\3\3\3\5\3r\n\3"+
+    "\3\3\3\3\3\3\5\3w\n\3\3\3\3\3\5\3{\n\3\5\3}\n\3\3\4\3\4\7\4\u0081\n\4"+
+    "\f\4\16\4\u0084\13\4\3\4\3\4\5\4\u0088\n\4\3\5\3\5\3\6\3\6\5\6\u008e\n"+
+    "\6\3\7\3\7\3\b\3\b\3\b\3\b\7\b\u0096\n\b\f\b\16\b\u0099\13\b\3\t\3\t\3"+
+    "\t\7\t\u009e\n\t\f\t\16\t\u00a1\13\t\3\n\3\n\3\n\5\n\u00a6\n\n\3\13\3"+
+    "\13\3\13\3\13\5\13\u00ac\n\13\3\f\3\f\3\f\3\r\3\r\3\r\3\r\3\r\3\r\3\r"+
+    "\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3"+
+    "\r\3\r\3\r\3\r\5\r\u00cd\n\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3"+
     "\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r"+
-    "\3\r\3\r\7\r\u00f0\n\r\f\r\16\r\u00f3\13\r\3\16\3\16\3\16\3\16\3\16\5"+
-    "\16\u00fa\n\16\3\17\3\17\3\17\3\17\3\17\3\17\5\17\u0102\n\17\3\17\3\17"+
-    "\3\17\5\17\u0107\n\17\3\20\3\20\3\20\3\20\3\20\3\20\3\20\3\20\5\20\u0111"+
-    "\n\20\3\21\3\21\3\21\3\21\3\21\5\21\u0118\n\21\3\22\3\22\3\22\5\22\u011d"+
-    "\n\22\3\23\3\23\3\23\3\24\3\24\3\24\3\24\5\24\u0126\n\24\3\25\3\25\3\25"+
-    "\5\25\u012b\n\25\3\26\3\26\3\26\3\26\3\26\5\26\u0132\n\26\3\26\3\26\3"+
-    "\26\3\26\6\26\u0138\n\26\r\26\16\26\u0139\3\26\5\26\u013d\n\26\5\26\u013f"+
-    "\n\26\3\27\3\27\3\27\3\27\7\27\u0145\n\27\f\27\16\27\u0148\13\27\5\27"+
-    "\u014a\n\27\3\27\3\27\3\30\3\30\3\30\2\3\30\31\2\4\6\b\n\f\16\20\22\24"+
-    "\26\30\32\34\36 \"$&(*,.\2\13\4\2\27\30\34\35\3\2\62=\3\2?B\3\2\31\33"+
-    "\3\2\34\35\3\2\36 \3\2!$\3\2%(\3\2\60\61\u0187\2\61\3\2\2\2\4x\3\2\2\2"+
-    "\6\u0083\3\2\2\2\b\u0085\3\2\2\2\n\u0089\3\2\2\2\f\u008b\3\2\2\2\16\u008d"+
-    "\3\2\2\2\20\u0096\3\2\2\2\22\u009e\3\2\2\2\24\u00a7\3\2\2\2\26\u00a9\3"+
-    "\2\2\2\30\u00c9\3\2\2\2\32\u00f9\3\2\2\2\34\u00fb\3\2\2\2\36\u0108\3\2"+
-    "\2\2 \u0112\3\2\2\2\"\u0119\3\2\2\2$\u011e\3\2\2\2&\u0121\3\2\2\2(\u0127"+
-    "\3\2\2\2*\u012c\3\2\2\2,\u0140\3\2\2\2.\u014d\3\2\2\2\60\62\5\4\3\2\61"+
-    "\60\3\2\2\2\62\63\3\2\2\2\63\61\3\2\2\2\63\64\3\2\2\2\64\65\3\2\2\2\65"+
-    "\66\7\2\2\3\66\3\3\2\2\2\678\7\16\2\289\7\t\2\29:\5\30\r\2:;\7\n\2\2;"+
-    ">\5\6\4\2<=\7\17\2\2=?\5\6\4\2><\3\2\2\2>?\3\2\2\2?y\3\2\2\2@A\7\20\2"+
-    "\2AB\7\t\2\2BC\5\30\r\2CF\7\n\2\2DG\5\6\4\2EG\5\b\5\2FD\3\2\2\2FE\3\2"+
-    "\2\2Gy\3\2\2\2HI\7\21\2\2IJ\5\6\4\2JK\7\20\2\2KL\7\t\2\2LM\5\30\r\2MO"+
-    "\7\n\2\2NP\7\r\2\2ON\3\2\2\2OP\3\2\2\2Py\3\2\2\2QR\7\22\2\2RT\7\t\2\2"+
-    "SU\5\n\6\2TS\3\2\2\2TU\3\2\2\2UV\3\2\2\2VX\7\r\2\2WY\5\30\r\2XW\3\2\2"+
-    "\2XY\3\2\2\2YZ\3\2\2\2Z\\\7\r\2\2[]\5\f\7\2\\[\3\2\2\2\\]\3\2\2\2]^\3"+
-    "\2\2\2^a\7\n\2\2_b\5\6\4\2`b\5\b\5\2a_\3\2\2\2a`\3\2\2\2by\3\2\2\2ce\5"+
-    "\16\b\2df\7\r\2\2ed\3\2\2\2ef\3\2\2\2fy\3\2\2\2gi\7\23\2\2hj\7\r\2\2i"+
-    "h\3\2\2\2ij\3\2\2\2jy\3\2\2\2km\7\24\2\2ln\7\r\2\2ml\3\2\2\2mn\3\2\2\2"+
-    "ny\3\2\2\2op\7\25\2\2pr\5\30\r\2qs\7\r\2\2rq\3\2\2\2rs\3\2\2\2sy\3\2\2"+
-    "\2tv\5\30\r\2uw\7\r\2\2vu\3\2\2\2vw\3\2\2\2wy\3\2\2\2x\67\3\2\2\2x@\3"+
-    "\2\2\2xH\3\2\2\2xQ\3\2\2\2xc\3\2\2\2xg\3\2\2\2xk\3\2\2\2xo\3\2\2\2xt\3"+
-    "\2\2\2y\5\3\2\2\2z~\7\5\2\2{}\5\4\3\2|{\3\2\2\2}\u0080\3\2\2\2~|\3\2\2"+
-    "\2~\177\3\2\2\2\177\u0081\3\2\2\2\u0080~\3\2\2\2\u0081\u0084\7\6\2\2\u0082"+
-    "\u0084\5\4\3\2\u0083z\3\2\2\2\u0083\u0082\3\2\2\2\u0084\7\3\2\2\2\u0085"+
-    "\u0086\7\r\2\2\u0086\t\3\2\2\2\u0087\u008a\5\16\b\2\u0088\u008a\5\30\r"+
-    "\2\u0089\u0087\3\2\2\2\u0089\u0088\3\2\2\2\u008a\13\3\2\2\2\u008b\u008c"+
-    "\5\30\r\2\u008c\r\3\2\2\2\u008d\u008e\5\20\t\2\u008e\u0093\5\22\n\2\u008f"+
-    "\u0090\7\f\2\2\u0090\u0092\5\22\n\2\u0091\u008f\3\2\2\2\u0092\u0095\3"+
-    "\2\2\2\u0093\u0091\3\2\2\2\u0093\u0094\3\2\2\2\u0094\17\3\2\2\2\u0095"+
-    "\u0093\3\2\2\2\u0096\u009b\5\24\13\2\u0097\u0098\7\7\2\2\u0098\u009a\7"+
-    "\b\2\2\u0099\u0097\3\2\2\2\u009a\u009d\3\2\2\2\u009b\u0099\3\2\2\2\u009b"+
-    "\u009c\3\2\2\2\u009c\21\3\2\2\2\u009d\u009b\3\2\2\2\u009e\u00a1\5\26\f"+
-    "\2\u009f\u00a0\7\62\2\2\u00a0\u00a2\5\30\r\2\u00a1\u009f\3\2\2\2\u00a1"+
-    "\u00a2\3\2\2\2\u00a2\23\3\2\2\2\u00a3\u00a4\6\13\2\2\u00a4\u00a8\7H\2"+
-    "\2\u00a5\u00a6\6\13\3\2\u00a6\u00a8\7I\2\2\u00a7\u00a3\3\2\2\2\u00a7\u00a5"+
-    "\3\2\2\2\u00a8\25\3\2\2\2\u00a9\u00aa\6\f\4\2\u00aa\u00ab\7H\2\2\u00ab"+
-    "\27\3\2\2\2\u00ac\u00ad\b\r\1\2\u00ad\u00ae\t\2\2\2\u00ae\u00ca\5\30\r"+
-    "\20\u00af\u00b0\7\t\2\2\u00b0\u00b1\5\20\t\2\u00b1\u00b2\7\n\2\2\u00b2"+
-    "\u00b3\5\30\r\17\u00b3\u00ca\3\2\2\2\u00b4\u00b5\5\32\16\2\u00b5\u00b6"+
-    "\t\3\2\2\u00b6\u00b7\5\30\r\3\u00b7\u00ca\3\2\2\2\u00b8\u00b9\7\t\2\2"+
-    "\u00b9\u00ba\5\30\r\2\u00ba\u00bb\7\n\2\2\u00bb\u00ca\3\2\2\2\u00bc\u00ca"+
-    "\t\4\2\2\u00bd\u00ca\7C\2\2\u00be\u00ca\7D\2\2\u00bf\u00ca\7E\2\2\u00c0"+
-    "\u00ca\7F\2\2\u00c1\u00ca\7G\2\2\u00c2\u00ca\5\32\16\2\u00c3\u00c4\5\32"+
-    "\16\2\u00c4\u00c5\5.\30\2\u00c5\u00ca\3\2\2\2\u00c6\u00c7\5.\30\2\u00c7"+
-    "\u00c8\5\32\16\2\u00c8\u00ca\3\2\2\2\u00c9\u00ac\3\2\2\2\u00c9\u00af\3"+
-    "\2\2\2\u00c9\u00b4\3\2\2\2\u00c9\u00b8\3\2\2\2\u00c9\u00bc\3\2\2\2\u00c9"+
-    "\u00bd\3\2\2\2\u00c9\u00be\3\2\2\2\u00c9\u00bf\3\2\2\2\u00c9\u00c0\3\2"+
-    "\2\2\u00c9\u00c1\3\2\2\2\u00c9\u00c2\3\2\2\2\u00c9\u00c3\3\2\2\2\u00c9"+
-    "\u00c6\3\2\2\2\u00ca\u00f1\3\2\2\2\u00cb\u00cc\f\16\2\2\u00cc\u00cd\t"+
-    "\5\2\2\u00cd\u00f0\5\30\r\17\u00ce\u00cf\f\r\2\2\u00cf\u00d0\t\6\2\2\u00d0"+
-    "\u00f0\5\30\r\16\u00d1\u00d2\f\f\2\2\u00d2\u00d3\t\7\2\2\u00d3\u00f0\5"+
-    "\30\r\r\u00d4\u00d5\f\13\2\2\u00d5\u00d6\t\b\2\2\u00d6\u00f0\5\30\r\f"+
-    "\u00d7\u00d8\f\n\2\2\u00d8\u00d9\t\t\2\2\u00d9\u00f0\5\30\r\13\u00da\u00db"+
-    "\f\t\2\2\u00db\u00dc\7)\2\2\u00dc\u00f0\5\30\r\n\u00dd\u00de\f\b\2\2\u00de"+
-    "\u00df\7*\2\2\u00df\u00f0\5\30\r\t\u00e0\u00e1\f\7\2\2\u00e1\u00e2\7+"+
-    "\2\2\u00e2\u00f0\5\30\r\b\u00e3\u00e4\f\6\2\2\u00e4\u00e5\7,\2\2\u00e5"+
-    "\u00f0\5\30\r\7\u00e6\u00e7\f\5\2\2\u00e7\u00e8\7-\2\2\u00e8\u00f0\5\30"+
-    "\r\6\u00e9\u00ea\f\4\2\2\u00ea\u00eb\7.\2\2\u00eb\u00ec\5\30\r\2\u00ec"+
-    "\u00ed\7/\2\2\u00ed\u00ee\5\30\r\4\u00ee\u00f0\3\2\2\2\u00ef\u00cb\3\2"+
-    "\2\2\u00ef\u00ce\3\2\2\2\u00ef\u00d1\3\2\2\2\u00ef\u00d4\3\2\2\2\u00ef"+
-    "\u00d7\3\2\2\2\u00ef\u00da\3\2\2\2\u00ef\u00dd\3\2\2\2\u00ef\u00e0\3\2"+
-    "\2\2\u00ef\u00e3\3\2\2\2\u00ef\u00e6\3\2\2\2\u00ef\u00e9\3\2\2\2\u00f0"+
-    "\u00f3\3\2\2\2\u00f1\u00ef\3\2\2\2\u00f1\u00f2\3\2\2\2\u00f2\31\3\2\2"+
-    "\2\u00f3\u00f1\3\2\2\2\u00f4\u00fa\5\34\17\2\u00f5\u00fa\5\36\20\2\u00f6"+
-    "\u00fa\5$\23\2\u00f7\u00fa\5(\25\2\u00f8\u00fa\5*\26\2\u00f9\u00f4\3\2"+
-    "\2\2\u00f9\u00f5\3\2\2\2\u00f9\u00f6\3\2\2\2\u00f9\u00f7\3\2\2\2\u00f9"+
-    "\u00f8\3\2\2\2\u00fa\33\3\2\2\2\u00fb\u0101\7\t\2\2\u00fc\u0102\5\34\17"+
-    "\2\u00fd\u0102\5\36\20\2\u00fe\u0102\5$\23\2\u00ff\u0102\5(\25\2\u0100"+
-    "\u0102\5*\26\2\u0101\u00fc\3\2\2\2\u0101\u00fd\3\2\2\2\u0101\u00fe\3\2"+
-    "\2\2\u0101\u00ff\3\2\2\2\u0101\u0100\3\2\2\2\u0102\u0103\3\2\2\2\u0103"+
-    "\u0106\7\n\2\2\u0104\u0107\5\"\22\2\u0105\u0107\5 \21\2\u0106\u0104\3"+
-    "\2\2\2\u0106\u0105\3\2\2\2\u0106\u0107\3\2\2\2\u0107\35\3\2\2\2\u0108"+
-    "\u0109\7\t\2\2\u0109\u010a\5\20\t\2\u010a\u0110\7\n\2\2\u010b\u0111\5"+
-    "\34\17\2\u010c\u0111\5\36\20\2\u010d\u0111\5$\23\2\u010e\u0111\5(\25\2"+
-    "\u010f\u0111\5*\26\2\u0110\u010b\3\2\2\2\u0110\u010c\3\2\2\2\u0110\u010d"+
-    "\3\2\2\2\u0110\u010e\3\2\2\2\u0110\u010f\3\2\2\2\u0111\37\3\2\2\2\u0112"+
-    "\u0113\7\7\2\2\u0113\u0114\5\30\r\2\u0114\u0117\7\b\2\2\u0115\u0118\5"+
-    "\"\22\2\u0116\u0118\5 \21\2\u0117\u0115\3\2\2\2\u0117\u0116\3\2\2\2\u0117"+
-    "\u0118\3\2\2\2\u0118!\3\2\2\2\u0119\u011c\7\13\2\2\u011a\u011d\5&\24\2"+
-    "\u011b\u011d\5(\25\2\u011c\u011a\3\2\2\2\u011c\u011b\3\2\2\2\u011d#\3"+
-    "\2\2\2\u011e\u011f\5\24\13\2\u011f\u0120\5\"\22\2\u0120%\3\2\2\2\u0121"+
-    "\u0122\5\26\f\2\u0122\u0125\5,\27\2\u0123\u0126\5\"\22\2\u0124\u0126\5"+
-    " \21\2\u0125\u0123\3\2\2\2\u0125\u0124\3\2\2\2\u0125\u0126\3\2\2\2\u0126"+
-    "\'\3\2\2\2\u0127\u012a\5\26\f\2\u0128\u012b\5\"\22\2\u0129\u012b\5 \21"+
-    "\2\u012a\u0128\3\2\2\2\u012a\u0129\3\2\2\2\u012a\u012b\3\2\2\2\u012b)"+
-    "\3\2\2\2\u012c\u012d\7\26\2\2\u012d\u013e\5\24\13\2\u012e\u0131\5,\27"+
-    "\2\u012f\u0132\5\"\22\2\u0130\u0132\5 \21\2\u0131\u012f\3\2\2\2\u0131"+
-    "\u0130\3\2\2\2\u0131\u0132\3\2\2\2\u0132\u013f\3\2\2\2\u0133\u0134\7\7"+
-    "\2\2\u0134\u0135\5\30\r\2\u0135\u0136\7\b\2\2\u0136\u0138\3\2\2\2\u0137"+
-    "\u0133\3\2\2\2\u0138\u0139\3\2\2\2\u0139\u0137\3\2\2\2\u0139\u013a\3\2"+
-    "\2\2\u013a\u013c\3\2\2\2\u013b\u013d\5\"\22\2\u013c\u013b\3\2\2\2\u013c"+
-    "\u013d\3\2\2\2\u013d\u013f\3\2\2\2\u013e\u012e\3\2\2\2\u013e\u0137\3\2"+
-    "\2\2\u013f+\3\2\2\2\u0140\u0149\7\t\2\2\u0141\u0146\5\30\r\2\u0142\u0143"+
-    "\7\f\2\2\u0143\u0145\5\30\r\2\u0144\u0142\3\2\2\2\u0145\u0148\3\2\2\2"+
-    "\u0146\u0144\3\2\2\2\u0146\u0147\3\2\2\2\u0147\u014a\3\2\2\2\u0148\u0146"+
-    "\3\2\2\2\u0149\u0141\3\2\2\2\u0149\u014a\3\2\2\2\u014a\u014b\3\2\2\2\u014b"+
-    "\u014c\7\n\2\2\u014c-\3\2\2\2\u014d\u014e\t\n\2\2\u014e/\3\2\2\2(\63>"+
-    "FOTX\\aeimrvx~\u0083\u0089\u0093\u009b\u00a1\u00a7\u00c9\u00ef\u00f1\u00f9"+
-    "\u0101\u0106\u0110\u0117\u011c\u0125\u012a\u0131\u0139\u013c\u013e\u0146"+
-    "\u0149";
+    "\3\r\3\r\3\r\3\r\3\r\3\r\3\r\3\r\7\r\u00f3\n\r\f\r\16\r\u00f6\13\r\3\16"+
+    "\3\16\3\16\3\16\3\16\3\16\5\16\u00fe\n\16\3\17\3\17\3\17\3\17\3\17\3\17"+
+    "\3\17\5\17\u0107\n\17\3\17\3\17\3\17\5\17\u010c\n\17\3\20\3\20\3\20\3"+
+    "\20\3\20\3\20\3\20\3\20\3\20\5\20\u0117\n\20\3\21\3\21\3\21\3\21\3\21"+
+    "\5\21\u011e\n\21\3\22\3\22\3\22\5\22\u0123\n\22\3\23\3\23\3\23\3\24\3"+
+    "\24\3\24\3\24\5\24\u012c\n\24\3\25\3\25\3\25\5\25\u0131\n\25\3\26\3\26"+
+    "\3\26\5\26\u0136\n\26\3\27\3\27\3\27\3\27\3\27\5\27\u013d\n\27\3\27\3"+
+    "\27\3\27\3\27\6\27\u0143\n\27\r\27\16\27\u0144\3\27\5\27\u0148\n\27\5"+
+    "\27\u014a\n\27\3\30\3\30\3\30\5\30\u014f\n\30\3\31\3\31\3\31\3\31\7\31"+
+    "\u0155\n\31\f\31\16\31\u0158\13\31\5\31\u015a\n\31\3\31\3\31\3\32\3\32"+
+    "\3\32\2\3\30\33\2\4\6\b\n\f\16\20\22\24\26\30\32\34\36 \"$&(*,.\60\62"+
+    "\2\13\4\2\27\30\34\35\3\2\62=\3\2?B\3\2\31\33\3\2\34\35\3\2\36 \3\2!$"+
+    "\3\2%(\3\2\60\61\u019b\2\65\3\2\2\2\4|\3\2\2\2\6\u0087\3\2\2\2\b\u0089"+
+    "\3\2\2\2\n\u008d\3\2\2\2\f\u008f\3\2\2\2\16\u0091\3\2\2\2\20\u009a\3\2"+
+    "\2\2\22\u00a2\3\2\2\2\24\u00ab\3\2\2\2\26\u00ad\3\2\2\2\30\u00cc\3\2\2"+
+    "\2\32\u00fd\3\2\2\2\34\u00ff\3\2\2\2\36\u010d\3\2\2\2 \u0118\3\2\2\2\""+
+    "\u011f\3\2\2\2$\u0124\3\2\2\2&\u0127\3\2\2\2(\u012d\3\2\2\2*\u0132\3\2"+
+    "\2\2,\u0137\3\2\2\2.\u014b\3\2\2\2\60\u0150\3\2\2\2\62\u015d\3\2\2\2\64"+
+    "\66\5\4\3\2\65\64\3\2\2\2\66\67\3\2\2\2\67\65\3\2\2\2\678\3\2\2\289\3"+
+    "\2\2\29:\7\2\2\3:\3\3\2\2\2;<\7\16\2\2<=\7\t\2\2=>\5\30\r\2>?\7\n\2\2"+
+    "?B\5\6\4\2@A\7\17\2\2AC\5\6\4\2B@\3\2\2\2BC\3\2\2\2C}\3\2\2\2DE\7\20\2"+
+    "\2EF\7\t\2\2FG\5\30\r\2GJ\7\n\2\2HK\5\6\4\2IK\5\b\5\2JH\3\2\2\2JI\3\2"+
+    "\2\2K}\3\2\2\2LM\7\21\2\2MN\5\6\4\2NO\7\20\2\2OP\7\t\2\2PQ\5\30\r\2QS"+
+    "\7\n\2\2RT\7\r\2\2SR\3\2\2\2ST\3\2\2\2T}\3\2\2\2UV\7\22\2\2VX\7\t\2\2"+
+    "WY\5\n\6\2XW\3\2\2\2XY\3\2\2\2YZ\3\2\2\2Z\\\7\r\2\2[]\5\30\r\2\\[\3\2"+
+    "\2\2\\]\3\2\2\2]^\3\2\2\2^`\7\r\2\2_a\5\f\7\2`_\3\2\2\2`a\3\2\2\2ab\3"+
+    "\2\2\2be\7\n\2\2cf\5\6\4\2df\5\b\5\2ec\3\2\2\2ed\3\2\2\2f}\3\2\2\2gi\5"+
+    "\16\b\2hj\7\r\2\2ih\3\2\2\2ij\3\2\2\2j}\3\2\2\2km\7\23\2\2ln\7\r\2\2m"+
+    "l\3\2\2\2mn\3\2\2\2n}\3\2\2\2oq\7\24\2\2pr\7\r\2\2qp\3\2\2\2qr\3\2\2\2"+
+    "r}\3\2\2\2st\7\25\2\2tv\5\30\r\2uw\7\r\2\2vu\3\2\2\2vw\3\2\2\2w}\3\2\2"+
+    "\2xz\5\30\r\2y{\7\r\2\2zy\3\2\2\2z{\3\2\2\2{}\3\2\2\2|;\3\2\2\2|D\3\2"+
+    "\2\2|L\3\2\2\2|U\3\2\2\2|g\3\2\2\2|k\3\2\2\2|o\3\2\2\2|s\3\2\2\2|x\3\2"+
+    "\2\2}\5\3\2\2\2~\u0082\7\5\2\2\177\u0081\5\4\3\2\u0080\177\3\2\2\2\u0081"+
+    "\u0084\3\2\2\2\u0082\u0080\3\2\2\2\u0082\u0083\3\2\2\2\u0083\u0085\3\2"+
+    "\2\2\u0084\u0082\3\2\2\2\u0085\u0088\7\6\2\2\u0086\u0088\5\4\3\2\u0087"+
+    "~\3\2\2\2\u0087\u0086\3\2\2\2\u0088\7\3\2\2\2\u0089\u008a\7\r\2\2\u008a"+
+    "\t\3\2\2\2\u008b\u008e\5\16\b\2\u008c\u008e\5\30\r\2\u008d\u008b\3\2\2"+
+    "\2\u008d\u008c\3\2\2\2\u008e\13\3\2\2\2\u008f\u0090\5\30\r\2\u0090\r\3"+
+    "\2\2\2\u0091\u0092\5\20\t\2\u0092\u0097\5\22\n\2\u0093\u0094\7\f\2\2\u0094"+
+    "\u0096\5\22\n\2\u0095\u0093\3\2\2\2\u0096\u0099\3\2\2\2\u0097\u0095\3"+
+    "\2\2\2\u0097\u0098\3\2\2\2\u0098\17\3\2\2\2\u0099\u0097\3\2\2\2\u009a"+
+    "\u009f\5\24\13\2\u009b\u009c\7\7\2\2\u009c\u009e\7\b\2\2\u009d\u009b\3"+
+    "\2\2\2\u009e\u00a1\3\2\2\2\u009f\u009d\3\2\2\2\u009f\u00a0\3\2\2\2\u00a0"+
+    "\21\3\2\2\2\u00a1\u009f\3\2\2\2\u00a2\u00a5\5\26\f\2\u00a3\u00a4\7\62"+
+    "\2\2\u00a4\u00a6\5\30\r\2\u00a5\u00a3\3\2\2\2\u00a5\u00a6\3\2\2\2\u00a6"+
+    "\23\3\2\2\2\u00a7\u00a8\6\13\2\2\u00a8\u00ac\7H\2\2\u00a9\u00aa\6\13\3"+
+    "\2\u00aa\u00ac\7I\2\2\u00ab\u00a7\3\2\2\2\u00ab\u00a9\3\2\2\2\u00ac\25"+
+    "\3\2\2\2\u00ad\u00ae\6\f\4\2\u00ae\u00af\7H\2\2\u00af\27\3\2\2\2\u00b0"+
+    "\u00b1\b\r\1\2\u00b1\u00b2\t\2\2\2\u00b2\u00cd\5\30\r\20\u00b3\u00b4\7"+
+    "\t\2\2\u00b4\u00b5\5\20\t\2\u00b5\u00b6\7\n\2\2\u00b6\u00b7\5\30\r\17"+
+    "\u00b7\u00cd\3\2\2\2\u00b8\u00b9\5\32\16\2\u00b9\u00ba\t\3\2\2\u00ba\u00bb"+
+    "\5\30\r\3\u00bb\u00cd\3\2\2\2\u00bc\u00bd\7\t\2\2\u00bd\u00be\5\30\r\2"+
+    "\u00be\u00bf\7\n\2\2\u00bf\u00cd\3\2\2\2\u00c0\u00cd\t\4\2\2\u00c1\u00cd"+
+    "\7D\2\2\u00c2\u00cd\7E\2\2\u00c3\u00cd\7F\2\2\u00c4\u00cd\7G\2\2\u00c5"+
+    "\u00cd\5\32\16\2\u00c6\u00c7\5\32\16\2\u00c7\u00c8\5\62\32\2\u00c8\u00cd"+
+    "\3\2\2\2\u00c9\u00ca\5\62\32\2\u00ca\u00cb\5\32\16\2\u00cb\u00cd\3\2\2"+
+    "\2\u00cc\u00b0\3\2\2\2\u00cc\u00b3\3\2\2\2\u00cc\u00b8\3\2\2\2\u00cc\u00bc"+
+    "\3\2\2\2\u00cc\u00c0\3\2\2\2\u00cc\u00c1\3\2\2\2\u00cc\u00c2\3\2\2\2\u00cc"+
+    "\u00c3\3\2\2\2\u00cc\u00c4\3\2\2\2\u00cc\u00c5\3\2\2\2\u00cc\u00c6\3\2"+
+    "\2\2\u00cc\u00c9\3\2\2\2\u00cd\u00f4\3\2\2\2\u00ce\u00cf\f\16\2\2\u00cf"+
+    "\u00d0\t\5\2\2\u00d0\u00f3\5\30\r\17\u00d1\u00d2\f\r\2\2\u00d2\u00d3\t"+
+    "\6\2\2\u00d3\u00f3\5\30\r\16\u00d4\u00d5\f\f\2\2\u00d5\u00d6\t\7\2\2\u00d6"+
+    "\u00f3\5\30\r\r\u00d7\u00d8\f\13\2\2\u00d8\u00d9\t\b\2\2\u00d9\u00f3\5"+
+    "\30\r\f\u00da\u00db\f\n\2\2\u00db\u00dc\t\t\2\2\u00dc\u00f3\5\30\r\13"+
+    "\u00dd\u00de\f\t\2\2\u00de\u00df\7)\2\2\u00df\u00f3\5\30\r\n\u00e0\u00e1"+
+    "\f\b\2\2\u00e1\u00e2\7*\2\2\u00e2\u00f3\5\30\r\t\u00e3\u00e4\f\7\2\2\u00e4"+
+    "\u00e5\7+\2\2\u00e5\u00f3\5\30\r\b\u00e6\u00e7\f\6\2\2\u00e7\u00e8\7,"+
+    "\2\2\u00e8\u00f3\5\30\r\7\u00e9\u00ea\f\5\2\2\u00ea\u00eb\7-\2\2\u00eb"+
+    "\u00f3\5\30\r\6\u00ec\u00ed\f\4\2\2\u00ed\u00ee\7.\2\2\u00ee\u00ef\5\30"+
+    "\r\2\u00ef\u00f0\7/\2\2\u00f0\u00f1\5\30\r\4\u00f1\u00f3\3\2\2\2\u00f2"+
+    "\u00ce\3\2\2\2\u00f2\u00d1\3\2\2\2\u00f2\u00d4\3\2\2\2\u00f2\u00d7\3\2"+
+    "\2\2\u00f2\u00da\3\2\2\2\u00f2\u00dd\3\2\2\2\u00f2\u00e0\3\2\2\2\u00f2"+
+    "\u00e3\3\2\2\2\u00f2\u00e6\3\2\2\2\u00f2\u00e9\3\2\2\2\u00f2\u00ec\3\2"+
+    "\2\2\u00f3\u00f6\3\2\2\2\u00f4\u00f2\3\2\2\2\u00f4\u00f5\3\2\2\2\u00f5"+
+    "\31\3\2\2\2\u00f6\u00f4\3\2\2\2\u00f7\u00fe\5\34\17\2\u00f8\u00fe\5\36"+
+    "\20\2\u00f9\u00fe\5$\23\2\u00fa\u00fe\5(\25\2\u00fb\u00fe\5,\27\2\u00fc"+
+    "\u00fe\5.\30\2\u00fd\u00f7\3\2\2\2\u00fd\u00f8\3\2\2\2\u00fd\u00f9\3\2"+
+    "\2\2\u00fd\u00fa\3\2\2\2\u00fd\u00fb\3\2\2\2\u00fd\u00fc\3\2\2\2\u00fe"+
+    "\33\3\2\2\2\u00ff\u0106\7\t\2\2\u0100\u0107\5\34\17\2\u0101\u0107\5\36"+
+    "\20\2\u0102\u0107\5$\23\2\u0103\u0107\5(\25\2\u0104\u0107\5,\27\2\u0105"+
+    "\u0107\5.\30\2\u0106\u0100\3\2\2\2\u0106\u0101\3\2\2\2\u0106\u0102\3\2"+
+    "\2\2\u0106\u0103\3\2\2\2\u0106\u0104\3\2\2\2\u0106\u0105\3\2\2\2\u0107"+
+    "\u0108\3\2\2\2\u0108\u010b\7\n\2\2\u0109\u010c\5\"\22\2\u010a\u010c\5"+
+    " \21\2\u010b\u0109\3\2\2\2\u010b\u010a\3\2\2\2\u010b\u010c\3\2\2\2\u010c"+
+    "\35\3\2\2\2\u010d\u010e\7\t\2\2\u010e\u010f\5\20\t\2\u010f\u0116\7\n\2"+
+    "\2\u0110\u0117\5\34\17\2\u0111\u0117\5\36\20\2\u0112\u0117\5$\23\2\u0113"+
+    "\u0117\5(\25\2\u0114\u0117\5,\27\2\u0115\u0117\5.\30\2\u0116\u0110\3\2"+
+    "\2\2\u0116\u0111\3\2\2\2\u0116\u0112\3\2\2\2\u0116\u0113\3\2\2\2\u0116"+
+    "\u0114\3\2\2\2\u0116\u0115\3\2\2\2\u0117\37\3\2\2\2\u0118\u0119\7\7\2"+
+    "\2\u0119\u011a\5\30\r\2\u011a\u011d\7\b\2\2\u011b\u011e\5\"\22\2\u011c"+
+    "\u011e\5 \21\2\u011d\u011b\3\2\2\2\u011d\u011c\3\2\2\2\u011d\u011e\3\2"+
+    "\2\2\u011e!\3\2\2\2\u011f\u0122\7\13\2\2\u0120\u0123\5&\24\2\u0121\u0123"+
+    "\5*\26\2\u0122\u0120\3\2\2\2\u0122\u0121\3\2\2\2\u0123#\3\2\2\2\u0124"+
+    "\u0125\5\24\13\2\u0125\u0126\5\"\22\2\u0126%\3\2\2\2\u0127\u0128\5\26"+
+    "\f\2\u0128\u012b\5\60\31\2\u0129\u012c\5\"\22\2\u012a\u012c\5 \21\2\u012b"+
+    "\u0129\3\2\2\2\u012b\u012a\3\2\2\2\u012b\u012c\3\2\2\2\u012c\'\3\2\2\2"+
+    "\u012d\u0130\5\26\f\2\u012e\u0131\5\"\22\2\u012f\u0131\5 \21\2\u0130\u012e"+
+    "\3\2\2\2\u0130\u012f\3\2\2\2\u0130\u0131\3\2\2\2\u0131)\3\2\2\2\u0132"+
+    "\u0135\5\26\f\2\u0133\u0136\5\"\22\2\u0134\u0136\5 \21\2\u0135\u0133\3"+
+    "\2\2\2\u0135\u0134\3\2\2\2\u0135\u0136\3\2\2\2\u0136+\3\2\2\2\u0137\u0138"+
+    "\7\26\2\2\u0138\u0149\5\24\13\2\u0139\u013c\5\60\31\2\u013a\u013d\5\""+
+    "\22\2\u013b\u013d\5 \21\2\u013c\u013a\3\2\2\2\u013c\u013b\3\2\2\2\u013c"+
+    "\u013d\3\2\2\2\u013d\u014a\3\2\2\2\u013e\u013f\7\7\2\2\u013f\u0140\5\30"+
+    "\r\2\u0140\u0141\7\b\2\2\u0141\u0143\3\2\2\2\u0142\u013e\3\2\2\2\u0143"+
+    "\u0144\3\2\2\2\u0144\u0142\3\2\2\2\u0144\u0145\3\2\2\2\u0145\u0147\3\2"+
+    "\2\2\u0146\u0148\5\"\22\2\u0147\u0146\3\2\2\2\u0147\u0148\3\2\2\2\u0148"+
+    "\u014a\3\2\2\2\u0149\u0139\3\2\2\2\u0149\u0142\3\2\2\2\u014a-\3\2\2\2"+
+    "\u014b\u014e\7C\2\2\u014c\u014f\5\"\22\2\u014d\u014f\5 \21\2\u014e\u014c"+
+    "\3\2\2\2\u014e\u014d\3\2\2\2\u014e\u014f\3\2\2\2\u014f/\3\2\2\2\u0150"+
+    "\u0159\7\t\2\2\u0151\u0156\5\30\r\2\u0152\u0153\7\f\2\2\u0153\u0155\5"+
+    "\30\r\2\u0154\u0152\3\2\2\2\u0155\u0158\3\2\2\2\u0156\u0154\3\2\2\2\u0156"+
+    "\u0157\3\2\2\2\u0157\u015a\3\2\2\2\u0158\u0156\3\2\2\2\u0159\u0151\3\2"+
+    "\2\2\u0159\u015a\3\2\2\2\u015a\u015b\3\2\2\2\u015b\u015c\7\n\2\2\u015c"+
+    "\61\3\2\2\2\u015d\u015e\t\n\2\2\u015e\63\3\2\2\2*\67BJSX\\`eimqvz|\u0082"+
+    "\u0087\u008d\u0097\u009f\u00a5\u00ab\u00cc\u00f2\u00f4\u00fd\u0106\u010b"+
+    "\u0116\u011d\u0122\u012b\u0130\u0135\u013c\u0144\u0147\u0149\u014e\u0156"+
+    "\u0159";
   public static final ATN _ATN =
     new ATNDeserializer().deserialize(_serializedATN.toCharArray());
   static {

--- a/src/main/java/org/elasticsearch/plan/a/PlanAVisitor.java
+++ b/src/main/java/org/elasticsearch/plan/a/PlanAVisitor.java
@@ -305,11 +305,11 @@ interface PlanAVisitor<T> extends ParseTreeVisitor<T> {
    */
   T visitExtvar(PlanAParser.ExtvarContext ctx);
   /**
-   * Visit a parse tree produced by {@link PlanAParser#extmember}.
+   * Visit a parse tree produced by {@link PlanAParser#extfield}.
    * @param ctx the parse tree
    * @return the visitor result
    */
-  T visitExtmember(PlanAParser.ExtmemberContext ctx);
+  T visitExtfield(PlanAParser.ExtfieldContext ctx);
   /**
    * Visit a parse tree produced by {@link PlanAParser#extnew}.
    * @param ctx the parse tree

--- a/src/main/java/org/elasticsearch/plan/a/PlanAVisitor.java
+++ b/src/main/java/org/elasticsearch/plan/a/PlanAVisitor.java
@@ -152,13 +152,6 @@ interface PlanAVisitor<T> extends ParseTreeVisitor<T> {
    */
   T visitComp(PlanAParser.CompContext ctx);
   /**
-   * Visit a parse tree produced by the {@code string}
-   * labeled alternative in {@link PlanAParser#expression}.
-   * @param ctx the parse tree
-   * @return the visitor result
-   */
-  T visitString(PlanAParser.StringContext ctx);
-  /**
    * Visit a parse tree produced by the {@code bool}
    * labeled alternative in {@link PlanAParser#expression}.
    * @param ctx the parse tree
@@ -306,6 +299,12 @@ interface PlanAVisitor<T> extends ParseTreeVisitor<T> {
    */
   T visitExtcall(PlanAParser.ExtcallContext ctx);
   /**
+   * Visit a parse tree produced by {@link PlanAParser#extvar}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitExtvar(PlanAParser.ExtvarContext ctx);
+  /**
    * Visit a parse tree produced by {@link PlanAParser#extmember}.
    * @param ctx the parse tree
    * @return the visitor result
@@ -317,6 +316,12 @@ interface PlanAVisitor<T> extends ParseTreeVisitor<T> {
    * @return the visitor result
    */
   T visitExtnew(PlanAParser.ExtnewContext ctx);
+  /**
+   * Visit a parse tree produced by {@link PlanAParser#extstring}.
+   * @param ctx the parse tree
+   * @return the visitor result
+   */
+  T visitExtstring(PlanAParser.ExtstringContext ctx);
   /**
    * Visit a parse tree produced by {@link PlanAParser#arguments}.
    * @param ctx the parse tree

--- a/src/main/java/org/elasticsearch/plan/a/Utility.java
+++ b/src/main/java/org/elasticsearch/plan/a/Utility.java
@@ -483,22 +483,42 @@ public class Utility {
      * Like {@link Math#toIntExact(long)} but for byte range.
      */
     public static byte toByteExact(int value) {
-        byte b = (byte) value;
-        if (b != value) {
+        byte s = (byte) value;
+        if (s != value) {
             throw new ArithmeticException("byte overflow");
         }
-        return b;
+        return s;
     }
 
     /**
-     * Like {@link Math#toIntExact(long)} but for char range.
+     * Like {@link Math#toIntExact(long)} but for byte range.
      */
-    public static char toCharExact(int value) {
-        char c = (char) value;
-        if (c != value) {
-            throw new ArithmeticException("char overflow");
+    public static byte toByteExact(long value) {
+        byte s = (byte) value;
+        if (s != value) {
+            throw new ArithmeticException("byte overflow");
         }
-        return c;
+        return s;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for byte range.
+     */
+    public static byte toByteExact(float value) {
+        if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+            throw new ArithmeticException("byte overflow");
+        }
+        return (byte)value;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for byte range.
+     */
+    public static byte toByteExact(double value) {
+        if (value < Byte.MIN_VALUE || value > Byte.MAX_VALUE) {
+            throw new ArithmeticException("byte overflow");
+        }
+        return (byte)value;
     }
 
     /**
@@ -511,7 +531,130 @@ public class Utility {
         }
         return s;
     }
-    
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for short range.
+     */
+    public static short toShortExact(long value) {
+        short s = (short) value;
+        if (s != value) {
+            throw new ArithmeticException("short overflow");
+        }
+        return s;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for short range.
+     */
+    public static short toShortExact(float value) {
+        if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
+            throw new ArithmeticException("short overflow");
+        }
+        return (short)value;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for short range.
+     */
+    public static short toShortExact(double value) {
+        if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
+            throw new ArithmeticException("short overflow");
+        }
+        return (short)value;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for char range.
+     */
+    public static char toCharExact(int value) {
+        char s = (char) value;
+        if (s != value) {
+            throw new ArithmeticException("char overflow");
+        }
+        return s;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for char range.
+     */
+    public static char toCharExact(long value) {
+        char s = (char) value;
+        if (s != value) {
+            throw new ArithmeticException("char overflow");
+        }
+        return s;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for char range.
+     */
+    public static char toCharExact(float value) {
+        if (value < Character.MIN_VALUE || value > Character.MAX_VALUE) {
+            throw new ArithmeticException("char overflow");
+        }
+        return (char)value;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for char range.
+     */
+    public static char toCharExact(double value) {
+        if (value < Character.MIN_VALUE || value > Character.MAX_VALUE) {
+            throw new ArithmeticException("char overflow");
+        }
+        return (char)value;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for int range.
+     */
+    public static int toIntExact(float value) {
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+            throw new ArithmeticException("int overflow");
+        }
+        return (int)value;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for int range.
+     */
+    public static int toIntExact(double value) {
+        if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+            throw new ArithmeticException("int overflow");
+        }
+        return (int)value;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for long range.
+     */
+    public static long toLongExact(float value) {
+        if (value < Long.MIN_VALUE || value > Long.MAX_VALUE) {
+            throw new ArithmeticException("long overflow");
+        }
+        return (long)value;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for long range.
+     */
+    public static float toLongExact(double value) {
+        if (value < Long.MIN_VALUE || value > Long.MAX_VALUE) {
+            throw new ArithmeticException("long overflow");
+        }
+        return (long)value;
+    }
+
+    /**
+     * Like {@link Math#toIntExact(long)} but for float range.
+     */
+    public static float toFloatExact(double value) {
+        if (value < Float.MIN_VALUE || value > Float.MAX_VALUE) {
+            throw new ArithmeticException("float overflow");
+        }
+        return (float)value;
+    }
+
     /**
      * Checks for overflow, result is infinite but operands are finite
      * @throws ArithmeticException if overflow occurred

--- a/src/main/java/org/elasticsearch/plan/a/Writer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Writer.java
@@ -555,23 +555,6 @@ class Writer extends PlanABaseVisitor<Void> {
     }
 
     @Override
-    public Void visitString(final StringContext ctx) {
-        final ExpressionMetadata stringemd = adapter.getExpressionMetadata(ctx);
-        final Object postConst = stringemd.postConst;
-
-        if (postConst == null) {
-            writeString(ctx, stringemd.preConst);
-            checkWriteCast(stringemd);
-        } else {
-            writeConstant(ctx, postConst);
-        }
-
-        checkWriteBranch(ctx);
-
-        return null;
-    }
-
-    @Override
     public Void visitChar(final CharContext ctx) {
         final ExpressionMetadata charemd = adapter.getExpressionMetadata(ctx);
         final Object postConst = charemd.postConst;
@@ -1151,22 +1134,23 @@ class Writer extends PlanABaseVisitor<Void> {
 
     @Override
     public Void visitExtstart(ExtstartContext ctx) {
-        final ExternalMetadata startenmd = adapter.getExternalMetadata(ctx);
+        final ExternalMetadata startemd = adapter.getExternalMetadata(ctx);
 
-        if (startenmd.token == ADD) {
-            final ExpressionMetadata storeemd = adapter.getExpressionMetadata(startenmd.storeExpr);
+        if (startemd.token == ADD) {
+            final ExpressionMetadata storeemd = adapter.getExpressionMetadata(startemd.storeExpr);
 
-            if (startenmd.current.sort == Sort.STRING || storeemd.from.sort == Sort.STRING) {
+            if (startemd.current.sort == Sort.STRING || storeemd.from.sort == Sort.STRING) {
                 writeNewStrings();
-                strings.add(startenmd.storeExpr);
+                strings.add(startemd.storeExpr);
             }
         }
 
         final ExtprecContext precctx = ctx.extprec();
         final ExtcastContext castctx = ctx.extcast();
         final ExttypeContext typectx = ctx.exttype();
-        final ExtmemberContext memberctx = ctx.extmember();
+        final ExtvarContext varctx = ctx.extvar();
         final ExtnewContext newctx = ctx.extnew();
+        final ExtstringContext stringctx = ctx.extstring();
 
         if (precctx != null) {
             visit(precctx);
@@ -1174,10 +1158,12 @@ class Writer extends PlanABaseVisitor<Void> {
             visit(castctx);
         } else if (typectx != null) {
             visit(typectx);
-        } else if (memberctx != null) {
-            visit(memberctx);
+        } else if (varctx != null) {
+            visit(varctx);
         } else if (newctx != null) {
             visit(newctx);
+        } else if (stringctx != null) {
+            visit(stringctx);
         } else {
             throw new IllegalStateException();
         }
@@ -1190,8 +1176,9 @@ class Writer extends PlanABaseVisitor<Void> {
         final ExtprecContext precctx = ctx.extprec();
         final ExtcastContext castctx = ctx.extcast();
         final ExttypeContext typectx = ctx.exttype();
-        final ExtmemberContext memberctx = ctx.extmember();
+        final ExtvarContext varctx = ctx.extvar();
         final ExtnewContext newctx = ctx.extnew();
+        final ExtstringContext stringctx = ctx.extstring();
 
         if (precctx != null) {
             visit(precctx);
@@ -1199,10 +1186,12 @@ class Writer extends PlanABaseVisitor<Void> {
             visit(castctx);
         } else if (typectx != null) {
             visit(typectx);
-        } else if (memberctx != null) {
-            visit(memberctx);
+        } else if (varctx != null) {
+            visit(varctx);
         } else if (newctx != null) {
             visit(newctx);
+        } else if (stringctx != null) {
+            visit(stringctx);
         } else {
             throw new IllegalStateException(error(ctx) + "Unexpected writer state.");
         }
@@ -1226,8 +1215,9 @@ class Writer extends PlanABaseVisitor<Void> {
         final ExtprecContext precctx = ctx.extprec();
         final ExtcastContext castctx = ctx.extcast();
         final ExttypeContext typectx = ctx.exttype();
-        final ExtmemberContext memberctx = ctx.extmember();
+        final ExtvarContext varctx = ctx.extvar();
         final ExtnewContext newctx = ctx.extnew();
+        final ExtstringContext stringctx = ctx.extstring();
 
         if (precctx != null) {
             visit(precctx);
@@ -1235,10 +1225,12 @@ class Writer extends PlanABaseVisitor<Void> {
             visit(castctx);
         } else if (typectx != null) {
             visit(typectx);
-        } else if (memberctx != null) {
-            visit(memberctx);
+        } else if (varctx != null) {
+            visit(varctx);
         } else if (newctx != null) {
             visit(newctx);
+        } else if (stringctx != null) {
+            visit(stringctx);
         } else {
             throw new IllegalStateException(error(ctx) + "Unexpected writer state.");
         }
@@ -1305,6 +1297,22 @@ class Writer extends PlanABaseVisitor<Void> {
     }
 
     @Override
+    public Void visitExtvar(final ExtvarContext ctx) {
+        writeLoadStoreExternal(ctx);
+
+        final ExtdotContext dotctx = ctx.extdot();
+        final ExtbraceContext bracectx = ctx.extbrace();
+
+        if (dotctx != null) {
+            visit(dotctx);
+        } else if (bracectx != null) {
+            visit(bracectx);
+        }
+
+        return null;
+    }
+
+    @Override
     public Void visitExtmember(final ExtmemberContext ctx) {
         writeLoadStoreExternal(ctx);
 
@@ -1323,6 +1331,24 @@ class Writer extends PlanABaseVisitor<Void> {
     @Override
     public Void visitExtnew(ExtnewContext ctx) {
         writeNewExternal(ctx);
+
+        final ExtdotContext dotctx = ctx.extdot();
+        final ExtbraceContext bracectx = ctx.extbrace();
+
+        if (dotctx != null) {
+            visit(dotctx);
+        } else if (bracectx != null) {
+            visit(bracectx);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Void visitExtstring(ExtstringContext ctx) {
+        final ExtNodeMetadata stringenmd = adapter.getExtNodeMetadata(ctx);
+
+        writeConstant(ctx, stringenmd.target);
 
         final ExtdotContext dotctx = ctx.extdot();
         final ExtbraceContext bracectx = ctx.extbrace();

--- a/src/main/java/org/elasticsearch/plan/a/Writer.java
+++ b/src/main/java/org/elasticsearch/plan/a/Writer.java
@@ -84,14 +84,42 @@ class Writer extends PlanABaseVisitor<Void> {
     private final static org.objectweb.asm.commons.Method DEF_FIELD_LOAD = org.objectweb.asm.commons.Method.getMethod(
             "java.lang.Object fieldLoad(java.lang.Object, java.lang.String, org.elasticsearch.plan.a.Definition)");
 
+    private final static org.objectweb.asm.commons.Method DEF_NOT_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "java.lang.Object not(java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_NEG_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "java.lang.Object neg(java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_MUL_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "java.lang.Object mul(java.lang.Object, java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_DIV_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "java.lang.Object div(java.lang.Object, java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_REM_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "java.lang.Object rem(java.lang.Object, java.lang.Object)");
     private final static org.objectweb.asm.commons.Method DEF_ADD_CALL = org.objectweb.asm.commons.Method.getMethod(
-            "java.lang.Object add(java.lang.Object, java.lang.Object, boolean)");
+            "java.lang.Object add(java.lang.Object, java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_SUB_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "java.lang.Object sub(java.lang.Object, java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_LSH_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "java.lang.Object lsh(java.lang.Object, java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_RSH_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "java.lang.Object rsh(java.lang.Object, java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_USH_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "java.lang.Object ush(java.lang.Object, java.lang.Object)");
     private final static org.objectweb.asm.commons.Method DEF_AND_CALL = org.objectweb.asm.commons.Method.getMethod(
             "java.lang.Object and(java.lang.Object, java.lang.Object)");
     private final static org.objectweb.asm.commons.Method DEF_XOR_CALL = org.objectweb.asm.commons.Method.getMethod(
             "java.lang.Object xor(java.lang.Object, java.lang.Object)");
     private final static org.objectweb.asm.commons.Method DEF_OR_CALL = org.objectweb.asm.commons.Method.getMethod(
             "java.lang.Object or(java.lang.Object, java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_EQ_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "boolean eq(java.lang.Object, java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_LT_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "boolean lt(java.lang.Object, java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_LTE_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "boolean lte(java.lang.Object, java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_GT_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "boolean gt(java.lang.Object, java.lang.Object)");
+    private final static org.objectweb.asm.commons.Method DEF_GTE_CALL = org.objectweb.asm.commons.Method.getMethod(
+            "boolean gte(java.lang.Object, java.lang.Object)");
 
     private final static org.objectweb.asm.Type STRINGBUILDER_TYPE = org.objectweb.asm.Type.getType(StringBuilder.class);
 
@@ -116,6 +144,8 @@ class Writer extends PlanABaseVisitor<Void> {
     private final static org.objectweb.asm.commons.Method STRINGBUILDER_TOSTRING =
             org.objectweb.asm.commons.Method.getMethod("java.lang.String toString()");
 
+    private final static org.objectweb.asm.commons.Method TOINTEXACT_LONG =
+            org.objectweb.asm.commons.Method.getMethod("int toIntExact(long)");
     private final static org.objectweb.asm.commons.Method NEGATEEXACT_INT =
             org.objectweb.asm.commons.Method.getMethod("int negateExact(int)");
     private final static org.objectweb.asm.commons.Method NEGATEEXACT_LONG =
@@ -135,12 +165,40 @@ class Writer extends PlanABaseVisitor<Void> {
 
     private final static org.objectweb.asm.commons.Method CHECKEQUALS =
             org.objectweb.asm.commons.Method.getMethod("boolean checkEquals(java.lang.Object, java.lang.Object)");
-    private final static org.objectweb.asm.commons.Method TOEXACT_BYTE =
+    private final static org.objectweb.asm.commons.Method TOBYTEEXACT_INT =
             org.objectweb.asm.commons.Method.getMethod("byte toByteExact(int)");
-    private final static org.objectweb.asm.commons.Method TOEXACT_SHORT =
+    private final static org.objectweb.asm.commons.Method TOBYTEEXACT_LONG =
+            org.objectweb.asm.commons.Method.getMethod("byte toByteExact(long)");
+    private final static org.objectweb.asm.commons.Method TOBYTEEXACT_FLOAT =
+            org.objectweb.asm.commons.Method.getMethod("byte toByteExact(float)");
+    private final static org.objectweb.asm.commons.Method TOBYTEEXACT_DOUBLE =
+            org.objectweb.asm.commons.Method.getMethod("byte toByteExact(double)");
+    private final static org.objectweb.asm.commons.Method TOSHORTEXACT_INT =
             org.objectweb.asm.commons.Method.getMethod("short toShortExact(int)");
-    private final static org.objectweb.asm.commons.Method TOEXACT_CHAR =
+    private final static org.objectweb.asm.commons.Method TOSHORTEXACT_LONG =
+            org.objectweb.asm.commons.Method.getMethod("short toShortExact(long)");
+    private final static org.objectweb.asm.commons.Method TOSHORTEXACT_FLOAT =
+            org.objectweb.asm.commons.Method.getMethod("short toShortExact(float)");
+    private final static org.objectweb.asm.commons.Method TOSHORTEXACT_DOUBLE =
+            org.objectweb.asm.commons.Method.getMethod("short toShortExact(double)");
+    private final static org.objectweb.asm.commons.Method TOCHAREXACT_INT =
             org.objectweb.asm.commons.Method.getMethod("char toCharExact(int)");
+    private final static org.objectweb.asm.commons.Method TOCHAREXACT_LONG =
+            org.objectweb.asm.commons.Method.getMethod("char toCharExact(long)");
+    private final static org.objectweb.asm.commons.Method TOCHAREXACT_FLOAT =
+            org.objectweb.asm.commons.Method.getMethod("char toCharExact(float)");
+    private final static org.objectweb.asm.commons.Method TOCHAREXACT_DOUBLE =
+            org.objectweb.asm.commons.Method.getMethod("char toCharExact(double)");
+    private final static org.objectweb.asm.commons.Method TOINTEXACT_FLOAT =
+            org.objectweb.asm.commons.Method.getMethod("int toIntExact(float)");
+    private final static org.objectweb.asm.commons.Method TOINTEXACT_DOUBLE =
+            org.objectweb.asm.commons.Method.getMethod("int toIntExact(double)");
+    private final static org.objectweb.asm.commons.Method TOLONGEXACT_FLOAT =
+            org.objectweb.asm.commons.Method.getMethod("long toLongExact(float)");
+    private final static org.objectweb.asm.commons.Method TOLONGEXACT_DOUBLE =
+            org.objectweb.asm.commons.Method.getMethod("long toLongExact(double)");
+    private final static org.objectweb.asm.commons.Method TOFLOATEXACT_DOUBLE =
+            org.objectweb.asm.commons.Method.getMethod("float toFloatExact(double)");
     private final static org.objectweb.asm.commons.Method MULWOOVERLOW_FLOAT =
             org.objectweb.asm.commons.Method.getMethod("float multiplyWithoutOverflow(float, float)");
     private final static org.objectweb.asm.commons.Method MULWOOVERLOW_DOUBLE =
@@ -714,25 +772,33 @@ class Writer extends PlanABaseVisitor<Void> {
                 visit(exprctx);
 
                 if (ctx.BWNOT() != null) {
-                    if (sort == Sort.INT)  {
-                        writeConstant(ctx, -1);
-                    } else if (sort == Sort.LONG) {
-                        writeConstant(ctx, -1L);
-                    } else {
-                        throw new IllegalStateException(error(ctx) + "Unexpected writer state.");
-                    }
-
-                    execute.math(GeneratorAdapter.XOR, type);
-                } else if (ctx.SUB() != null) {
-                    if (settings.getNumericOverflow()) {
-                        execute.math(GeneratorAdapter.NEG, type);
+                    if (sort == Sort.DEF) {
+                        execute.invokeStatic(definition.defobjType.type, DEF_NOT_CALL);
                     } else {
                         if (sort == Sort.INT) {
-                            execute.invokeStatic(definition.mathType.type, NEGATEEXACT_INT);
+                            writeConstant(ctx, -1);
                         } else if (sort == Sort.LONG) {
-                            execute.invokeStatic(definition.mathType.type, NEGATEEXACT_LONG);
+                            writeConstant(ctx, -1L);
                         } else {
                             throw new IllegalStateException(error(ctx) + "Unexpected writer state.");
+                        }
+
+                        execute.math(GeneratorAdapter.XOR, type);
+                    }
+                } else if (ctx.SUB() != null) {
+                    if (sort == Sort.DEF) {
+                        execute.invokeStatic(definition.defobjType.type, DEF_NEG_CALL);
+                    } else {
+                        if (settings.getNumericOverflow()) {
+                            execute.math(GeneratorAdapter.NEG, type);
+                        } else {
+                            if (sort == Sort.INT) {
+                                execute.invokeStatic(definition.mathType.type, NEGATEEXACT_INT);
+                            } else if (sort == Sort.LONG) {
+                                execute.invokeStatic(definition.mathType.type, NEGATEEXACT_LONG);
+                            } else {
+                                throw new IllegalStateException(error(ctx) + "Unexpected writer state.");
+                            }
                         }
                     }
                 } else if (ctx.ADD() == null) {
@@ -793,7 +859,7 @@ class Writer extends PlanABaseVisitor<Void> {
             visit(exprctx0);
 
             if (strings.contains(exprctx0)) {
-                writeAppendStrings(ctx, expremd0.from.sort);
+                writeAppendStrings(expremd0.from.sort);
                 strings.remove(exprctx0);
             }
 
@@ -803,7 +869,7 @@ class Writer extends PlanABaseVisitor<Void> {
             visit(exprctx1);
 
             if (strings.contains(exprctx1)) {
-                writeAppendStrings(ctx, expremd1.from.sort);
+                writeAppendStrings(expremd1.from.sort);
                 strings.remove(exprctx1);
             }
 
@@ -811,23 +877,6 @@ class Writer extends PlanABaseVisitor<Void> {
                 strings.remove(ctx);
             } else {
                 writeToStrings();
-            }
-
-            checkWriteCast(binaryemd);
-        } else if (binaryemd.from.sort == Sort.DEF) {
-            final ExpressionContext exprctx0 = ctx.expression(0);
-            final ExpressionContext exprctx1 = ctx.expression(1);
-
-            visit(exprctx0);
-            visit(exprctx1);
-
-            if (ctx.ADD() != null) {
-                execute.push(settings.getNumericOverflow());
-                execute.invokeStatic(definition.defobjType.type, DEF_ADD_CALL);
-            } else if (ctx.BWXOR() != null) {
-                execute.invokeStatic(definition.defobjType.type, DEF_XOR_CALL);
-            } else {
-                throw new IllegalStateException(error(ctx) + "Unexpected writer state.");
             }
 
             checkWriteCast(binaryemd);
@@ -916,7 +965,7 @@ class Writer extends PlanABaseVisitor<Void> {
             final boolean gt  = ctx.GT()  != null && (tru || !fals) || ctx.LTE() != null && fals;
             final boolean gte = ctx.GTE() != null && (tru || !fals) || ctx.LT()  != null && fals;
 
-            boolean eqobj = false;
+            boolean writejump = true;
 
             switch (sort1) {
                 case VOID:
@@ -947,18 +996,12 @@ class Writer extends PlanABaseVisitor<Void> {
                     }
 
                     break;
-                default:
+                case DEF:
                     if (eq) {
                         if (expremd1.isNull) {
                             execute.ifNull(jump);
                         } else if (!expremd0.isNull && ctx.EQ() != null) {
-                            execute.invokeStatic(definition.utilityType.type, CHECKEQUALS);
-
-                            if (branch != null) {
-                                execute.ifZCmp(GeneratorAdapter.NE, jump);
-                            }
-
-                            eqobj = true;
+                            execute.invokeStatic(definition.defobjType.type, DEF_EQ_CALL);
                         } else {
                             execute.ifCmp(type, GeneratorAdapter.EQ, jump);
                         }
@@ -966,6 +1009,49 @@ class Writer extends PlanABaseVisitor<Void> {
                         if (expremd1.isNull) {
                             execute.ifNonNull(jump);
                         } else if (!expremd0.isNull && ctx.NE() != null) {
+                            execute.invokeStatic(definition.defobjType.type, DEF_EQ_CALL);
+                            execute.ifZCmp(GeneratorAdapter.EQ, jump);
+                        } else {
+                            execute.ifCmp(type, GeneratorAdapter.NE, jump);
+                        }
+                    } else if (lt) {
+                        execute.invokeStatic(definition.defobjType.type, DEF_LT_CALL);
+                    } else if (lte) {
+                        execute.invokeStatic(definition.defobjType.type, DEF_LTE_CALL);
+                    } else if (gt) {
+                        execute.invokeStatic(definition.defobjType.type, DEF_GT_CALL);
+                    } else if (gte) {
+                        execute.invokeStatic(definition.defobjType.type, DEF_GTE_CALL);
+                    } else {
+                        throw new IllegalStateException(error(ctx) + "Unexpected writer state.");
+                    }
+
+                    writejump = expremd1.isNull || ne || ctx.EQR() != null;
+
+                    if (branch != null && !writejump) {
+                        execute.ifZCmp(GeneratorAdapter.NE, jump);
+                    }
+
+                    break;
+                default:
+                    if (eq) {
+                        if (expremd1.isNull) {
+                            execute.ifNull(jump);
+                        } else if (ctx.EQ() != null) {
+                            execute.invokeStatic(definition.utilityType.type, CHECKEQUALS);
+
+                            if (branch != null) {
+                                execute.ifZCmp(GeneratorAdapter.NE, jump);
+                            }
+
+                            writejump = false;
+                        } else {
+                            execute.ifCmp(type, GeneratorAdapter.EQ, jump);
+                        }
+                    } else if (ne) {
+                        if (expremd1.isNull) {
+                            execute.ifNonNull(jump);
+                        } else if (ctx.NE() != null) {
                             execute.invokeStatic(definition.utilityType.type, CHECKEQUALS);
                             execute.ifZCmp(GeneratorAdapter.EQ, jump);
                         } else {
@@ -977,7 +1063,7 @@ class Writer extends PlanABaseVisitor<Void> {
             }
 
             if (branch == null) {
-                if (!eqobj) {
+                if (writejump) {
                     execute.push(false);
                     execute.goTo(end);
                     execute.mark(jump);
@@ -1262,12 +1348,12 @@ class Writer extends PlanABaseVisitor<Void> {
     @Override
     public Void visitExtdot(final ExtdotContext ctx) {
         final ExtcallContext callctx = ctx.extcall();
-        final ExtmemberContext memberctx = ctx.extmember();
+        final ExtfieldContext fieldctx = ctx.extfield();
 
         if (callctx != null) {
             visit(callctx);
-        } else if (memberctx != null) {
-            visit(memberctx);
+        } else if (fieldctx != null) {
+            visit(fieldctx);
         }
 
         return null;
@@ -1313,7 +1399,7 @@ class Writer extends PlanABaseVisitor<Void> {
     }
 
     @Override
-    public Void visitExtmember(final ExtmemberContext ctx) {
+    public Void visitExtfield(final ExtfieldContext ctx) {
         writeLoadStoreExternal(ctx);
 
         final ExtdotContext dotctx = ctx.extdot();
@@ -1434,7 +1520,7 @@ class Writer extends PlanABaseVisitor<Void> {
         execute.invokeConstructor(STRINGBUILDER_TYPE, STRINGBUILDER_CONSTRUCTOR);
     }
 
-    private void writeAppendStrings(final ParserRuleContext source, final Sort sort) {
+    private void writeAppendStrings(final Sort sort) {
         switch (sort) {
             case BOOL:   execute.invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_BOOLEAN); break;
             case CHAR:   execute.invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_CHAR);    break;
@@ -1445,39 +1531,12 @@ class Writer extends PlanABaseVisitor<Void> {
             case FLOAT:  execute.invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_FLOAT);   break;
             case DOUBLE: execute.invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_DOUBLE);  break;
             case STRING: execute.invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_STRING);  break;
-            case ARRAY:
-            case DEF:
-            case OBJECT: execute.invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_OBJECT);  break;
-            default:
-                throw new IllegalStateException(error(source) + "Unexpected writer state.");
+            default:     execute.invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_OBJECT);
         }
     }
 
     private void writeToStrings() {
         execute.invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_TOSTRING);
-    }
-
-    /**
-     * Called for any compound assignment (including increment/decrement instructions).
-     * We have to be stricter than writeBinary, and do overflow checks against the original type's size
-     * instead of the promoted type's size, since the result will be implicitly cast back.
-     */
-    private void writeCompoundAssignmentInstruction(ParserRuleContext source, Type original, Type promoted, int token) {
-        writeBinaryInstruction(source, promoted, token);
-        if (settings.getNumericOverflow() == false) {
-            if (token == ADD || token == SUB || token == MUL || token == DIV) {
-                if (original.sort == Sort.BYTE) {
-                    execute.invokeStatic(definition.utilityType.type, TOEXACT_BYTE);
-                } else if (original.sort == Sort.SHORT) {
-                    execute.invokeStatic(definition.utilityType.type, TOEXACT_SHORT);
-                } else if (original.sort == Sort.CHAR) {
-                    execute.invokeStatic(definition.utilityType.type, TOEXACT_CHAR);
-                } else {
-                    // all other types are never promoted during compound assignment
-                    assert original.sort == promoted.sort;
-                }
-            }
-        }
     }
 
     private void writeBinaryInstruction(final ParserRuleContext source, final Type type, final int token) {
@@ -1490,9 +1549,7 @@ class Writer extends PlanABaseVisitor<Void> {
 
         // if its a 64-bit shift, fixup the last argument to truncate to 32-bits
         // note unlike java, this means we still do binary promotion of shifts,
-        // but it keeps things simple
-
-        // this check works because we promote shifts.
+        // but it keeps things simple -- this check works because we promote shifts.
         if (sort == Sort.LONG && (token == LSH || token == USH || token == RSH)) {
             execute.cast(org.objectweb.asm.Type.LONG_TYPE, org.objectweb.asm.Type.INT_TYPE);
         }
@@ -1554,33 +1611,51 @@ class Writer extends PlanABaseVisitor<Void> {
                 throw new IllegalStateException(error(source) + "Unexpected writer state.");
             }
 
-            switch (token) {
-                case MUL:   execute.math(GeneratorAdapter.MUL,  type.type); break;
-                case DIV:   execute.math(GeneratorAdapter.DIV,  type.type); break;
-                case REM:   execute.math(GeneratorAdapter.REM,  type.type); break;
-                case ADD:   execute.math(GeneratorAdapter.ADD,  type.type); break;
-                case SUB:   execute.math(GeneratorAdapter.SUB,  type.type); break;
-                case LSH:   execute.math(GeneratorAdapter.SHL,  type.type); break;
-                case USH:   execute.math(GeneratorAdapter.USHR, type.type); break;
-                case RSH:   execute.math(GeneratorAdapter.SHR,  type.type); break;
-                case BWAND: execute.math(GeneratorAdapter.AND,  type.type); break;
-                case BWXOR: execute.math(GeneratorAdapter.XOR,  type.type); break;
-                case BWOR:  execute.math(GeneratorAdapter.OR,   type.type); break;
-                default:
-                    throw new IllegalStateException(error(source) + "Unexpected writer state.");
+            if (sort == Sort.DEF) {
+                switch (token) {
+                    case MUL:   execute.invokeStatic(definition.defobjType.type, DEF_MUL_CALL); break;
+                    case DIV:   execute.invokeStatic(definition.defobjType.type, DEF_DIV_CALL); break;
+                    case REM:   execute.invokeStatic(definition.defobjType.type, DEF_REM_CALL); break;
+                    case ADD:   execute.invokeStatic(definition.defobjType.type, DEF_ADD_CALL); break;
+                    case SUB:   execute.invokeStatic(definition.defobjType.type, DEF_SUB_CALL); break;
+                    case LSH:   execute.invokeStatic(definition.defobjType.type, DEF_LSH_CALL); break;
+                    case USH:   execute.invokeStatic(definition.defobjType.type, DEF_RSH_CALL); break;
+                    case RSH:   execute.invokeStatic(definition.defobjType.type, DEF_USH_CALL); break;
+                    case BWAND: execute.invokeStatic(definition.defobjType.type, DEF_AND_CALL); break;
+                    case BWXOR: execute.invokeStatic(definition.defobjType.type, DEF_XOR_CALL); break;
+                    case BWOR:  execute.invokeStatic(definition.defobjType.type, DEF_OR_CALL);  break;
+                    default:
+                        throw new IllegalStateException(error(source) + "Unexpected writer state.");
+                }
+            } else {
+                switch (token) {
+                    case MUL:   execute.math(GeneratorAdapter.MUL,  type.type); break;
+                    case DIV:   execute.math(GeneratorAdapter.DIV,  type.type); break;
+                    case REM:   execute.math(GeneratorAdapter.REM,  type.type); break;
+                    case ADD:   execute.math(GeneratorAdapter.ADD,  type.type); break;
+                    case SUB:   execute.math(GeneratorAdapter.SUB,  type.type); break;
+                    case LSH:   execute.math(GeneratorAdapter.SHL,  type.type); break;
+                    case USH:   execute.math(GeneratorAdapter.USHR, type.type); break;
+                    case RSH:   execute.math(GeneratorAdapter.SHR,  type.type); break;
+                    case BWAND: execute.math(GeneratorAdapter.AND,  type.type); break;
+                    case BWXOR: execute.math(GeneratorAdapter.XOR,  type.type); break;
+                    case BWOR:  execute.math(GeneratorAdapter.OR,   type.type); break;
+                    default:
+                        throw new IllegalStateException(error(source) + "Unexpected writer state.");
+                }
             }
         }
     }
 
     private void writeLoadStoreExternal(final ParserRuleContext source) {
-        final ExtNodeMetadata sourceemd = adapter.getExtNodeMetadata(source);
-        final ExternalMetadata parentemd = adapter.getExternalMetadata(sourceemd.parent);
+        final ExtNodeMetadata sourceenmd = adapter.getExtNodeMetadata(source);
+        final ExternalMetadata parentemd = adapter.getExternalMetadata(sourceenmd.parent);
 
-        final boolean length = "#length".equals(sourceemd.target);
-        final boolean array = "#brace".equals(sourceemd.target);
-        final boolean name = sourceemd.target instanceof String && !length && !array;
-        final boolean variable = sourceemd.target instanceof Integer;
-        final boolean field = sourceemd.target instanceof Field;
+        final boolean length = "#length".equals(sourceenmd.target);
+        final boolean array = "#brace".equals(sourceenmd.target);
+        final boolean name = sourceenmd.target instanceof String && !length && !array;
+        final boolean variable = sourceenmd.target instanceof Integer;
+        final boolean field = sourceenmd.target instanceof Field;
 
         if (!length && !variable && !field && !array && !name) {
             throw new IllegalStateException(error(source) + "Target not found for load/store.");
@@ -1588,7 +1663,7 @@ class Writer extends PlanABaseVisitor<Void> {
 
         if (length) {
             execute.arrayLength();
-        } else if (sourceemd.last && parentemd.storeExpr != null) {
+        } else if (sourceenmd.last && parentemd.storeExpr != null) {
             final ExpressionMetadata expremd = adapter.getExpressionMetadata(parentemd.storeExpr);
             final boolean cat = strings.contains(parentemd.storeExpr);
 
@@ -1600,23 +1675,25 @@ class Writer extends PlanABaseVisitor<Void> {
                 }
 
                 writeLoadStoreInstruction(source, false, variable, field, name, array);
-                writeAppendStrings(source, sourceemd.type.sort);
+                writeAppendStrings(sourceenmd.type.sort);
                 visit(parentemd.storeExpr);
 
                 if (strings.contains(parentemd.storeExpr)) {
-                    writeAppendStrings(parentemd.storeExpr, expremd.to.sort);
+                    writeAppendStrings(expremd.to.sort);
                     strings.remove(parentemd.storeExpr);
                 }
 
                 writeToStrings();
-                checkWriteCast(source, sourceemd.castTo);
+                checkWriteCast(source, sourceenmd.castTo);
 
                 if (parentemd.read) {
-                    writeDup(sourceemd.type.sort.size, field || name, array);
+                    writeDup(sourceenmd.type.sort.size, field || name, array);
                 }
 
                 writeLoadStoreInstruction(source, true, variable, field, name, array);
             } else if (parentemd.token > 0) {
+                final int token = parentemd.token;
+                
                 if (field || name) {
                     execute.dup();
                 } else if (array) {
@@ -1626,29 +1703,140 @@ class Writer extends PlanABaseVisitor<Void> {
                 writeLoadStoreInstruction(source, false, variable, field, name, array);
 
                 if (parentemd.read && parentemd.post) {
-                    writeDup(sourceemd.type.sort.size, field || name, array);
+                    writeDup(sourceenmd.type.sort.size, field || name, array);
                 }
 
-                checkWriteCast(source, sourceemd.castFrom);
+                checkWriteCast(source, sourceenmd.castFrom);
                 visit(parentemd.storeExpr);
 
-                if (parentemd.token == ADD && sourceemd.promote.sort == Sort.DEF) {
-                    execute.push(settings.getNumericOverflow());
-                    execute.invokeStatic(definition.defobjType.type, DEF_ADD_CALL);
-                } else if (parentemd.token == BWAND && sourceemd.promote.sort == Sort.DEF) {
-                    execute.invokeStatic(definition.defobjType.type, DEF_AND_CALL);
-                }  else if (parentemd.token == BWXOR && sourceemd.promote.sort == Sort.DEF) {
-                    execute.invokeStatic(definition.defobjType.type, DEF_XOR_CALL);
-                }  else if (parentemd.token == BWOR && sourceemd.promote.sort == Sort.DEF) {
-                    execute.invokeStatic(definition.defobjType.type, DEF_OR_CALL);
+                final Sort osort = sourceenmd.type.sort;
+                final Sort psort = sourceenmd.promote.sort;
+
+                writeBinaryInstruction(source, sourceenmd.promote, token);
+
+                /**
+                 * Called for any compound assignment (including increment/decrement instructions).
+                 * We have to be stricter than writeBinary, and do overflow checks against the original type's size
+                 * instead of the promoted type's size, since the result will be implicitly cast back.
+                 */
+
+                if (settings.getNumericOverflow() == false && expremd.typesafe && osort != Sort.DEF &&
+                        (token == MUL || token == DIV || token == REM || token == ADD || token == SUB)) {
+                    if (psort == Sort.DOUBLE) {
+                        if (osort == Sort.FLOAT) {
+                            execute.invokeStatic(definition.utilityType.type, TOFLOATEXACT_DOUBLE);
+                        } else if (osort == Sort.FLOAT_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOFLOATEXACT_DOUBLE);
+                            execute.checkCast(definition.floatobjType.type);
+                        } else if (osort == Sort.LONG) {
+                            execute.invokeStatic(definition.utilityType.type, TOLONGEXACT_DOUBLE);
+                        } else if (osort == Sort.LONG_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOLONGEXACT_DOUBLE);
+                            execute.checkCast(definition.longobjType.type);
+                        } else if (osort == Sort.INT) {
+                            execute.invokeStatic(definition.utilityType.type, TOINTEXACT_DOUBLE);
+                        } else if (osort == Sort.INT_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOINTEXACT_DOUBLE);
+                            execute.checkCast(definition.intobjType.type);
+                        } else if (osort == Sort.CHAR) {
+                            execute.invokeStatic(definition.utilityType.type, TOCHAREXACT_DOUBLE);
+                        } else if (osort == Sort.CHAR_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOCHAREXACT_DOUBLE);
+                            execute.checkCast(definition.charobjType.type);
+                        } else if (osort == Sort.SHORT) {
+                            execute.invokeStatic(definition.utilityType.type, TOSHORTEXACT_DOUBLE);
+                        } else if (osort == Sort.SHORT_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOSHORTEXACT_DOUBLE);
+                            execute.checkCast(definition.shortobjType.type);
+                        } else if (osort == Sort.BYTE) {
+                            execute.invokeStatic(definition.utilityType.type, TOBYTEEXACT_DOUBLE);
+                        } else if (osort == Sort.BYTE_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOBYTEEXACT_DOUBLE);
+                            execute.checkCast(definition.byteobjType.type);
+                        } else {
+                            checkWriteCast(source, sourceenmd.castTo);
+                        }
+                    } else if (psort == Sort.FLOAT) {
+                        if (osort == Sort.LONG) {
+                            execute.invokeStatic(definition.utilityType.type, TOLONGEXACT_FLOAT);
+                        } else if (osort == Sort.LONG_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOLONGEXACT_FLOAT);
+                            execute.checkCast(definition.longobjType.type);
+                        } else if (osort == Sort.INT) {
+                            execute.invokeStatic(definition.utilityType.type, TOINTEXACT_FLOAT);
+                        } else if (osort == Sort.INT_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOINTEXACT_FLOAT);
+                            execute.checkCast(definition.intobjType.type);
+                        } else if (osort == Sort.CHAR) {
+                            execute.invokeStatic(definition.utilityType.type, TOCHAREXACT_FLOAT);
+                        } else if (osort == Sort.CHAR_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOCHAREXACT_FLOAT);
+                            execute.checkCast(definition.charobjType.type);
+                        } else if (osort == Sort.SHORT) {
+                            execute.invokeStatic(definition.utilityType.type, TOSHORTEXACT_FLOAT);
+                        } else if (osort == Sort.SHORT_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOSHORTEXACT_FLOAT);
+                            execute.checkCast(definition.shortobjType.type);
+                        } else if (osort == Sort.BYTE) {
+                            execute.invokeStatic(definition.utilityType.type, TOBYTEEXACT_FLOAT);
+                        } else if (osort == Sort.BYTE_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOBYTEEXACT_FLOAT);
+                            execute.checkCast(definition.byteobjType.type);
+                        } else {
+                            checkWriteCast(source, sourceenmd.castTo);
+                        }
+                    } else if (psort == Sort.LONG) {
+                        if (osort == Sort.INT) {
+                            execute.invokeStatic(definition.mathType.type, TOINTEXACT_LONG);
+                        } else if (osort == Sort.INT_OBJ) {
+                            execute.invokeStatic(definition.mathType.type, TOINTEXACT_LONG);
+                            execute.checkCast(definition.intobjType.type);
+                        } else if (osort == Sort.CHAR) {
+                            execute.invokeStatic(definition.utilityType.type, TOCHAREXACT_LONG);
+                        } else if (osort == Sort.CHAR_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOCHAREXACT_LONG);
+                            execute.checkCast(definition.charobjType.type);
+                        } else if (osort == Sort.SHORT) {
+                            execute.invokeStatic(definition.utilityType.type, TOSHORTEXACT_LONG);
+                        } else if (osort == Sort.SHORT_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOSHORTEXACT_LONG);
+                            execute.checkCast(definition.shortobjType.type);
+                        } else if (osort == Sort.BYTE) {
+                            execute.invokeStatic(definition.utilityType.type, TOBYTEEXACT_LONG);
+                        } else if (osort == Sort.BYTE_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOBYTEEXACT_LONG);
+                            execute.checkCast(definition.byteobjType.type);
+                        } else {
+                            checkWriteCast(source, sourceenmd.castTo);
+                        }
+                    } else if (psort == Sort.INT) {
+                        if (osort == Sort.CHAR) {
+                            execute.invokeStatic(definition.utilityType.type, TOCHAREXACT_INT);
+                        } else if (osort == Sort.CHAR_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOCHAREXACT_INT);
+                            execute.checkCast(definition.charobjType.type);
+                        } else if (osort == Sort.SHORT) {
+                            execute.invokeStatic(definition.utilityType.type, TOSHORTEXACT_INT);
+                        } else if (osort == Sort.SHORT_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOSHORTEXACT_INT);
+                            execute.checkCast(definition.shortobjType.type);
+                        } else if (osort == Sort.BYTE) {
+                            execute.invokeStatic(definition.utilityType.type, TOBYTEEXACT_INT);
+                        } else if (osort == Sort.BYTE_OBJ) {
+                            execute.invokeStatic(definition.utilityType.type, TOBYTEEXACT_INT);
+                            execute.checkCast(definition.byteobjType.type);
+                        } else {
+                            checkWriteCast(source, sourceenmd.castTo);
+                        }
+                    } else {
+                        checkWriteCast(source, sourceenmd.castTo);
+                    }
                 } else {
-                    writeCompoundAssignmentInstruction(source, sourceemd.type, sourceemd.promote, parentemd.token);
+                    checkWriteCast(source, sourceenmd.castTo);
                 }
 
-                checkWriteCast(source, sourceemd.castTo);
-
                 if (parentemd.read && !parentemd.post) {
-                    writeDup(sourceemd.type.sort.size, field || name, array);
+                    writeDup(sourceenmd.type.sort.size, field || name, array);
                 }
 
                 writeLoadStoreInstruction(source, true, variable, field, name, array);
@@ -1656,7 +1844,7 @@ class Writer extends PlanABaseVisitor<Void> {
                 visit(parentemd.storeExpr);
 
                 if (parentemd.read) {
-                    writeDup(sourceemd.type.sort.size, field || name, array);
+                    writeDup(sourceenmd.type.sort.size, field || name, array);
                 }
 
                 writeLoadStoreInstruction(source, true, variable, field, name, array);

--- a/src/test/java/org/elasticsearch/plan/a/DefTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/DefTests.java
@@ -1,0 +1,914 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.plan.a;
+
+public class DefTests extends ScriptTestCase {
+    public void testNot() {
+        assertEquals(~1, exec("def x = (byte)1 return ~x"));
+        assertEquals(~1, exec("def x = (short)1 return ~x"));
+        assertEquals(~1, exec("def x = (char)1 return ~x"));
+        assertEquals(~1, exec("def x = 1 return ~x"));
+        assertEquals(~1L, exec("def x = 1L return ~x"));
+    }
+
+    public void testNeg() {
+        assertEquals(-1, exec("def x = (byte)1 return -x"));
+        assertEquals(-1, exec("def x = (short)1 return -x"));
+        assertEquals(-1, exec("def x = (char)1 return -x"));
+        assertEquals(-1, exec("def x = 1 return -x"));
+        assertEquals(-1L, exec("def x = 1L return -x"));
+        assertEquals(-1.0F, exec("def x = 1F return -x"));
+        assertEquals(-1.0, exec("def x = 1.0 return -x"));
+    }
+
+    public void testMul() {
+        assertEquals(4, exec("def x = (byte)2 def y = (byte)2 return x * y"));
+        assertEquals(4, exec("def x = (short)2 def y = (byte)2 return x * y"));
+        assertEquals(4, exec("def x = (char)2 def y = (byte)2 return x * y"));
+        assertEquals(4, exec("def x = (int)2 def y = (byte)2 return x * y"));
+        assertEquals(4L, exec("def x = (long)2 def y = (byte)2 return x * y"));
+        assertEquals(4F, exec("def x = (float)2 def y = (byte)2 return x * y"));
+        assertEquals(4D, exec("def x = (double)2 def y = (byte)2 return x * y"));
+
+        assertEquals(4, exec("def x = (byte)2 def y = (short)2 return x * y"));
+        assertEquals(4, exec("def x = (short)2 def y = (short)2 return x * y"));
+        assertEquals(4, exec("def x = (char)2 def y = (short)2 return x * y"));
+        assertEquals(4, exec("def x = (int)2 def y = (short)2 return x * y"));
+        assertEquals(4L, exec("def x = (long)2 def y = (short)2 return x * y"));
+        assertEquals(4F, exec("def x = (float)2 def y = (short)2 return x * y"));
+        assertEquals(4D, exec("def x = (double)2 def y = (short)2 return x * y"));
+
+        assertEquals(4, exec("def x = (byte)2 def y = (char)2 return x * y"));
+        assertEquals(4, exec("def x = (short)2 def y = (char)2 return x * y"));
+        assertEquals(4, exec("def x = (char)2 def y = (char)2 return x * y"));
+        assertEquals(4, exec("def x = (int)2 def y = (char)2 return x * y"));
+        assertEquals(4L, exec("def x = (long)2 def y = (char)2 return x * y"));
+        assertEquals(4F, exec("def x = (float)2 def y = (char)2 return x * y"));
+        assertEquals(4D, exec("def x = (double)2 def y = (char)2 return x * y"));
+
+        assertEquals(4, exec("def x = (byte)2 def y = (int)2 return x * y"));
+        assertEquals(4, exec("def x = (short)2 def y = (int)2 return x * y"));
+        assertEquals(4, exec("def x = (char)2 def y = (int)2 return x * y"));
+        assertEquals(4, exec("def x = (int)2 def y = (int)2 return x * y"));
+        assertEquals(4L, exec("def x = (long)2 def y = (int)2 return x * y"));
+        assertEquals(4F, exec("def x = (float)2 def y = (int)2 return x * y"));
+        assertEquals(4D, exec("def x = (double)2 def y = (int)2 return x * y"));
+
+        assertEquals(4L, exec("def x = (byte)2 def y = (long)2 return x * y"));
+        assertEquals(4L, exec("def x = (short)2 def y = (long)2 return x * y"));
+        assertEquals(4L, exec("def x = (char)2 def y = (long)2 return x * y"));
+        assertEquals(4L, exec("def x = (int)2 def y = (long)2 return x * y"));
+        assertEquals(4L, exec("def x = (long)2 def y = (long)2 return x * y"));
+        assertEquals(4F, exec("def x = (float)2 def y = (long)2 return x * y"));
+        assertEquals(4D, exec("def x = (double)2 def y = (long)2 return x * y"));
+
+        assertEquals(4F, exec("def x = (byte)2 def y = (float)2 return x * y"));
+        assertEquals(4F, exec("def x = (short)2 def y = (float)2 return x * y"));
+        assertEquals(4F, exec("def x = (char)2 def y = (float)2 return x * y"));
+        assertEquals(4F, exec("def x = (int)2 def y = (float)2 return x * y"));
+        assertEquals(4F, exec("def x = (long)2 def y = (float)2 return x * y"));
+        assertEquals(4F, exec("def x = (float)2 def y = (float)2 return x * y"));
+        assertEquals(4D, exec("def x = (double)2 def y = (float)2 return x * y"));
+
+        assertEquals(4D, exec("def x = (byte)2 def y = (double)2 return x * y"));
+        assertEquals(4D, exec("def x = (short)2 def y = (double)2 return x * y"));
+        assertEquals(4D, exec("def x = (char)2 def y = (double)2 return x * y"));
+        assertEquals(4D, exec("def x = (int)2 def y = (double)2 return x * y"));
+        assertEquals(4D, exec("def x = (long)2 def y = (double)2 return x * y"));
+        assertEquals(4D, exec("def x = (float)2 def y = (double)2 return x * y"));
+        assertEquals(4D, exec("def x = (double)2 def y = (double)2 return x * y"));
+
+        assertEquals(4, exec("def x = (Byte)2 def y = (byte)2 return x * y"));
+        assertEquals(4, exec("def x = (Short)2 def y = (short)2 return x * y"));
+        assertEquals(4, exec("def x = (Character)2 def y = (char)2 return x * y"));
+        assertEquals(4, exec("def x = (Integer)2 def y = (int)2 return x * y"));
+        assertEquals(4L, exec("def x = (Long)2 def y = (long)2 return x * y"));
+        assertEquals(4F, exec("def x = (Float)2 def y = (float)2 return x * y"));
+        assertEquals(4D, exec("def x = (Double)2 def y = (double)2 return x * y"));
+    }
+
+    public void testDiv() {
+        assertEquals(1, exec("def x = (byte)2 def y = (byte)2 return x / y"));
+        assertEquals(1, exec("def x = (short)2 def y = (byte)2 return x / y"));
+        assertEquals(1, exec("def x = (char)2 def y = (byte)2 return x / y"));
+        assertEquals(1, exec("def x = (int)2 def y = (byte)2 return x / y"));
+        assertEquals(1L, exec("def x = (long)2 def y = (byte)2 return x / y"));
+        assertEquals(1F, exec("def x = (float)2 def y = (byte)2 return x / y"));
+        assertEquals(1D, exec("def x = (double)2 def y = (byte)2 return x / y"));
+
+        assertEquals(1, exec("def x = (byte)2 def y = (short)2 return x / y"));
+        assertEquals(1, exec("def x = (short)2 def y = (short)2 return x / y"));
+        assertEquals(1, exec("def x = (char)2 def y = (short)2 return x / y"));
+        assertEquals(1, exec("def x = (int)2 def y = (short)2 return x / y"));
+        assertEquals(1L, exec("def x = (long)2 def y = (short)2 return x / y"));
+        assertEquals(1F, exec("def x = (float)2 def y = (short)2 return x / y"));
+        assertEquals(1D, exec("def x = (double)2 def y = (short)2 return x / y"));
+
+        assertEquals(1, exec("def x = (byte)2 def y = (char)2 return x / y"));
+        assertEquals(1, exec("def x = (short)2 def y = (char)2 return x / y"));
+        assertEquals(1, exec("def x = (char)2 def y = (char)2 return x / y"));
+        assertEquals(1, exec("def x = (int)2 def y = (char)2 return x / y"));
+        assertEquals(1L, exec("def x = (long)2 def y = (char)2 return x / y"));
+        assertEquals(1F, exec("def x = (float)2 def y = (char)2 return x / y"));
+        assertEquals(1D, exec("def x = (double)2 def y = (char)2 return x / y"));
+
+        assertEquals(1, exec("def x = (byte)2 def y = (int)2 return x / y"));
+        assertEquals(1, exec("def x = (short)2 def y = (int)2 return x / y"));
+        assertEquals(1, exec("def x = (char)2 def y = (int)2 return x / y"));
+        assertEquals(1, exec("def x = (int)2 def y = (int)2 return x / y"));
+        assertEquals(1L, exec("def x = (long)2 def y = (int)2 return x / y"));
+        assertEquals(1F, exec("def x = (float)2 def y = (int)2 return x / y"));
+        assertEquals(1D, exec("def x = (double)2 def y = (int)2 return x / y"));
+
+        assertEquals(1L, exec("def x = (byte)2 def y = (long)2 return x / y"));
+        assertEquals(1L, exec("def x = (short)2 def y = (long)2 return x / y"));
+        assertEquals(1L, exec("def x = (char)2 def y = (long)2 return x / y"));
+        assertEquals(1L, exec("def x = (int)2 def y = (long)2 return x / y"));
+        assertEquals(1L, exec("def x = (long)2 def y = (long)2 return x / y"));
+        assertEquals(1F, exec("def x = (float)2 def y = (long)2 return x / y"));
+        assertEquals(1D, exec("def x = (double)2 def y = (long)2 return x / y"));
+
+        assertEquals(1F, exec("def x = (byte)2 def y = (float)2 return x / y"));
+        assertEquals(1F, exec("def x = (short)2 def y = (float)2 return x / y"));
+        assertEquals(1F, exec("def x = (char)2 def y = (float)2 return x / y"));
+        assertEquals(1F, exec("def x = (int)2 def y = (float)2 return x / y"));
+        assertEquals(1F, exec("def x = (long)2 def y = (float)2 return x / y"));
+        assertEquals(1F, exec("def x = (float)2 def y = (float)2 return x / y"));
+        assertEquals(1D, exec("def x = (double)2 def y = (float)2 return x / y"));
+
+        assertEquals(1D, exec("def x = (byte)2 def y = (double)2 return x / y"));
+        assertEquals(1D, exec("def x = (short)2 def y = (double)2 return x / y"));
+        assertEquals(1D, exec("def x = (char)2 def y = (double)2 return x / y"));
+        assertEquals(1D, exec("def x = (int)2 def y = (double)2 return x / y"));
+        assertEquals(1D, exec("def x = (long)2 def y = (double)2 return x / y"));
+        assertEquals(1D, exec("def x = (float)2 def y = (double)2 return x / y"));
+        assertEquals(1D, exec("def x = (double)2 def y = (double)2 return x / y"));
+
+        assertEquals(1, exec("def x = (Byte)2 def y = (byte)2 return x / y"));
+        assertEquals(1, exec("def x = (Short)2 def y = (short)2 return x / y"));
+        assertEquals(1, exec("def x = (Character)2 def y = (char)2 return x / y"));
+        assertEquals(1, exec("def x = (Integer)2 def y = (int)2 return x / y"));
+        assertEquals(1L, exec("def x = (Long)2 def y = (long)2 return x / y"));
+        assertEquals(1F, exec("def x = (Float)2 def y = (float)2 return x / y"));
+        assertEquals(1D, exec("def x = (Double)2 def y = (double)2 return x / y"));
+    }
+
+    public void testRem() {
+        assertEquals(0, exec("def x = (byte)2 def y = (byte)2 return x % y"));
+        assertEquals(0, exec("def x = (short)2 def y = (byte)2 return x % y"));
+        assertEquals(0, exec("def x = (char)2 def y = (byte)2 return x % y"));
+        assertEquals(0, exec("def x = (int)2 def y = (byte)2 return x % y"));
+        assertEquals(0L, exec("def x = (long)2 def y = (byte)2 return x % y"));
+        assertEquals(0F, exec("def x = (float)2 def y = (byte)2 return x % y"));
+        assertEquals(0D, exec("def x = (double)2 def y = (byte)2 return x % y"));
+
+        assertEquals(0, exec("def x = (byte)2 def y = (short)2 return x % y"));
+        assertEquals(0, exec("def x = (short)2 def y = (short)2 return x % y"));
+        assertEquals(0, exec("def x = (char)2 def y = (short)2 return x % y"));
+        assertEquals(0, exec("def x = (int)2 def y = (short)2 return x % y"));
+        assertEquals(0L, exec("def x = (long)2 def y = (short)2 return x % y"));
+        assertEquals(0F, exec("def x = (float)2 def y = (short)2 return x % y"));
+        assertEquals(0D, exec("def x = (double)2 def y = (short)2 return x % y"));
+
+        assertEquals(0, exec("def x = (byte)2 def y = (char)2 return x % y"));
+        assertEquals(0, exec("def x = (short)2 def y = (char)2 return x % y"));
+        assertEquals(0, exec("def x = (char)2 def y = (char)2 return x % y"));
+        assertEquals(0, exec("def x = (int)2 def y = (char)2 return x % y"));
+        assertEquals(0L, exec("def x = (long)2 def y = (char)2 return x % y"));
+        assertEquals(0F, exec("def x = (float)2 def y = (char)2 return x % y"));
+        assertEquals(0D, exec("def x = (double)2 def y = (char)2 return x % y"));
+
+        assertEquals(0, exec("def x = (byte)2 def y = (int)2 return x % y"));
+        assertEquals(0, exec("def x = (short)2 def y = (int)2 return x % y"));
+        assertEquals(0, exec("def x = (char)2 def y = (int)2 return x % y"));
+        assertEquals(0, exec("def x = (int)2 def y = (int)2 return x % y"));
+        assertEquals(0L, exec("def x = (long)2 def y = (int)2 return x % y"));
+        assertEquals(0F, exec("def x = (float)2 def y = (int)2 return x % y"));
+        assertEquals(0D, exec("def x = (double)2 def y = (int)2 return x % y"));
+
+        assertEquals(0L, exec("def x = (byte)2 def y = (long)2 return x % y"));
+        assertEquals(0L, exec("def x = (short)2 def y = (long)2 return x % y"));
+        assertEquals(0L, exec("def x = (char)2 def y = (long)2 return x % y"));
+        assertEquals(0L, exec("def x = (int)2 def y = (long)2 return x % y"));
+        assertEquals(0L, exec("def x = (long)2 def y = (long)2 return x % y"));
+        assertEquals(0F, exec("def x = (float)2 def y = (long)2 return x % y"));
+        assertEquals(0D, exec("def x = (double)2 def y = (long)2 return x % y"));
+
+        assertEquals(0F, exec("def x = (byte)2 def y = (float)2 return x % y"));
+        assertEquals(0F, exec("def x = (short)2 def y = (float)2 return x % y"));
+        assertEquals(0F, exec("def x = (char)2 def y = (float)2 return x % y"));
+        assertEquals(0F, exec("def x = (int)2 def y = (float)2 return x % y"));
+        assertEquals(0F, exec("def x = (long)2 def y = (float)2 return x % y"));
+        assertEquals(0F, exec("def x = (float)2 def y = (float)2 return x % y"));
+        assertEquals(0D, exec("def x = (double)2 def y = (float)2 return x % y"));
+
+        assertEquals(0D, exec("def x = (byte)2 def y = (double)2 return x % y"));
+        assertEquals(0D, exec("def x = (short)2 def y = (double)2 return x % y"));
+        assertEquals(0D, exec("def x = (char)2 def y = (double)2 return x % y"));
+        assertEquals(0D, exec("def x = (int)2 def y = (double)2 return x % y"));
+        assertEquals(0D, exec("def x = (long)2 def y = (double)2 return x % y"));
+        assertEquals(0D, exec("def x = (float)2 def y = (double)2 return x % y"));
+        assertEquals(0D, exec("def x = (double)2 def y = (double)2 return x % y"));
+
+        assertEquals(0, exec("def x = (Byte)2 def y = (byte)2 return x % y"));
+        assertEquals(0, exec("def x = (Short)2 def y = (short)2 return x % y"));
+        assertEquals(0, exec("def x = (Character)2 def y = (char)2 return x % y"));
+        assertEquals(0, exec("def x = (Integer)2 def y = (int)2 return x % y"));
+        assertEquals(0L, exec("def x = (Long)2 def y = (long)2 return x % y"));
+        assertEquals(0F, exec("def x = (Float)2 def y = (float)2 return x % y"));
+        assertEquals(0D, exec("def x = (Double)2 def y = (double)2 return x % y"));
+    }
+    
+    public void testAdd() {
+        assertEquals(2, exec("def x = (byte)1 def y = (byte)1 return x + y"));
+        assertEquals(2, exec("def x = (short)1 def y = (byte)1 return x + y"));
+        assertEquals(2, exec("def x = (char)1 def y = (byte)1 return x + y"));
+        assertEquals(2, exec("def x = (int)1 def y = (byte)1 return x + y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (byte)1 return x + y"));
+        assertEquals(2F, exec("def x = (float)1 def y = (byte)1 return x + y"));
+        assertEquals(2D, exec("def x = (double)1 def y = (byte)1 return x + y"));
+
+        assertEquals(2, exec("def x = (byte)1 def y = (short)1 return x + y"));
+        assertEquals(2, exec("def x = (short)1 def y = (short)1 return x + y"));
+        assertEquals(2, exec("def x = (char)1 def y = (short)1 return x + y"));
+        assertEquals(2, exec("def x = (int)1 def y = (short)1 return x + y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (short)1 return x + y"));
+        assertEquals(2F, exec("def x = (float)1 def y = (short)1 return x + y"));
+        assertEquals(2D, exec("def x = (double)1 def y = (short)1 return x + y"));
+
+        assertEquals(2, exec("def x = (byte)1 def y = (char)1 return x + y"));
+        assertEquals(2, exec("def x = (short)1 def y = (char)1 return x + y"));
+        assertEquals(2, exec("def x = (char)1 def y = (char)1 return x + y"));
+        assertEquals(2, exec("def x = (int)1 def y = (char)1 return x + y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (char)1 return x + y"));
+        assertEquals(2F, exec("def x = (float)1 def y = (char)1 return x + y"));
+        assertEquals(2D, exec("def x = (double)1 def y = (char)1 return x + y"));
+
+        assertEquals(2, exec("def x = (byte)1 def y = (int)1 return x + y"));
+        assertEquals(2, exec("def x = (short)1 def y = (int)1 return x + y"));
+        assertEquals(2, exec("def x = (char)1 def y = (int)1 return x + y"));
+        assertEquals(2, exec("def x = (int)1 def y = (int)1 return x + y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (int)1 return x + y"));
+        assertEquals(2F, exec("def x = (float)1 def y = (int)1 return x + y"));
+        assertEquals(2D, exec("def x = (double)1 def y = (int)1 return x + y"));
+
+        assertEquals(2L, exec("def x = (byte)1 def y = (long)1 return x + y"));
+        assertEquals(2L, exec("def x = (short)1 def y = (long)1 return x + y"));
+        assertEquals(2L, exec("def x = (char)1 def y = (long)1 return x + y"));
+        assertEquals(2L, exec("def x = (int)1 def y = (long)1 return x + y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (long)1 return x + y"));
+        assertEquals(2F, exec("def x = (float)1 def y = (long)1 return x + y"));
+        assertEquals(2D, exec("def x = (double)1 def y = (long)1 return x + y"));
+
+        assertEquals(2F, exec("def x = (byte)1 def y = (float)1 return x + y"));
+        assertEquals(2F, exec("def x = (short)1 def y = (float)1 return x + y"));
+        assertEquals(2F, exec("def x = (char)1 def y = (float)1 return x + y"));
+        assertEquals(2F, exec("def x = (int)1 def y = (float)1 return x + y"));
+        assertEquals(2F, exec("def x = (long)1 def y = (float)1 return x + y"));
+        assertEquals(2F, exec("def x = (float)1 def y = (float)1 return x + y"));
+        assertEquals(2D, exec("def x = (double)1 def y = (float)1 return x + y"));
+
+        assertEquals(2D, exec("def x = (byte)1 def y = (double)1 return x + y"));
+        assertEquals(2D, exec("def x = (short)1 def y = (double)1 return x + y"));
+        assertEquals(2D, exec("def x = (char)1 def y = (double)1 return x + y"));
+        assertEquals(2D, exec("def x = (int)1 def y = (double)1 return x + y"));
+        assertEquals(2D, exec("def x = (long)1 def y = (double)1 return x + y"));
+        assertEquals(2D, exec("def x = (float)1 def y = (double)1 return x + y"));
+        assertEquals(2D, exec("def x = (double)1 def y = (double)1 return x + y"));
+
+        assertEquals(2, exec("def x = (Byte)1 def y = (byte)1 return x + y"));
+        assertEquals(2, exec("def x = (Short)1 def y = (short)1 return x + y"));
+        assertEquals(2, exec("def x = (Character)1 def y = (char)1 return x + y"));
+        assertEquals(2, exec("def x = (Integer)1 def y = (int)1 return x + y"));
+        assertEquals(2L, exec("def x = (Long)1 def y = (long)1 return x + y"));
+        assertEquals(2F, exec("def x = (Float)1 def y = (float)1 return x + y"));
+        assertEquals(2D, exec("def x = (Double)1 def y = (double)1 return x + y"));
+    }
+
+    public void testSub() {
+        assertEquals(0, exec("def x = (byte)1 def y = (byte)1 return x - y"));
+        assertEquals(0, exec("def x = (short)1 def y = (byte)1 return x - y"));
+        assertEquals(0, exec("def x = (char)1 def y = (byte)1 return x - y"));
+        assertEquals(0, exec("def x = (int)1 def y = (byte)1 return x - y"));
+        assertEquals(0L, exec("def x = (long)1 def y = (byte)1 return x - y"));
+        assertEquals(0F, exec("def x = (float)1 def y = (byte)1 return x - y"));
+        assertEquals(0D, exec("def x = (double)1 def y = (byte)1 return x - y"));
+
+        assertEquals(0, exec("def x = (byte)1 def y = (short)1 return x - y"));
+        assertEquals(0, exec("def x = (short)1 def y = (short)1 return x - y"));
+        assertEquals(0, exec("def x = (char)1 def y = (short)1 return x - y"));
+        assertEquals(0, exec("def x = (int)1 def y = (short)1 return x - y"));
+        assertEquals(0L, exec("def x = (long)1 def y = (short)1 return x - y"));
+        assertEquals(0F, exec("def x = (float)1 def y = (short)1 return x - y"));
+        assertEquals(0D, exec("def x = (double)1 def y = (short)1 return x - y"));
+
+        assertEquals(0, exec("def x = (byte)1 def y = (char)1 return x - y"));
+        assertEquals(0, exec("def x = (short)1 def y = (char)1 return x - y"));
+        assertEquals(0, exec("def x = (char)1 def y = (char)1 return x - y"));
+        assertEquals(0, exec("def x = (int)1 def y = (char)1 return x - y"));
+        assertEquals(0L, exec("def x = (long)1 def y = (char)1 return x - y"));
+        assertEquals(0F, exec("def x = (float)1 def y = (char)1 return x - y"));
+        assertEquals(0D, exec("def x = (double)1 def y = (char)1 return x - y"));
+
+        assertEquals(0, exec("def x = (byte)1 def y = (int)1 return x - y"));
+        assertEquals(0, exec("def x = (short)1 def y = (int)1 return x - y"));
+        assertEquals(0, exec("def x = (char)1 def y = (int)1 return x - y"));
+        assertEquals(0, exec("def x = (int)1 def y = (int)1 return x - y"));
+        assertEquals(0L, exec("def x = (long)1 def y = (int)1 return x - y"));
+        assertEquals(0F, exec("def x = (float)1 def y = (int)1 return x - y"));
+        assertEquals(0D, exec("def x = (double)1 def y = (int)1 return x - y"));
+
+        assertEquals(0L, exec("def x = (byte)1 def y = (long)1 return x - y"));
+        assertEquals(0L, exec("def x = (short)1 def y = (long)1 return x - y"));
+        assertEquals(0L, exec("def x = (char)1 def y = (long)1 return x - y"));
+        assertEquals(0L, exec("def x = (int)1 def y = (long)1 return x - y"));
+        assertEquals(0L, exec("def x = (long)1 def y = (long)1 return x - y"));
+        assertEquals(0F, exec("def x = (float)1 def y = (long)1 return x - y"));
+        assertEquals(0D, exec("def x = (double)1 def y = (long)1 return x - y"));
+
+        assertEquals(0F, exec("def x = (byte)1 def y = (float)1 return x - y"));
+        assertEquals(0F, exec("def x = (short)1 def y = (float)1 return x - y"));
+        assertEquals(0F, exec("def x = (char)1 def y = (float)1 return x - y"));
+        assertEquals(0F, exec("def x = (int)1 def y = (float)1 return x - y"));
+        assertEquals(0F, exec("def x = (long)1 def y = (float)1 return x - y"));
+        assertEquals(0F, exec("def x = (float)1 def y = (float)1 return x - y"));
+        assertEquals(0D, exec("def x = (double)1 def y = (float)1 return x - y"));
+
+        assertEquals(0D, exec("def x = (byte)1 def y = (double)1 return x - y"));
+        assertEquals(0D, exec("def x = (short)1 def y = (double)1 return x - y"));
+        assertEquals(0D, exec("def x = (char)1 def y = (double)1 return x - y"));
+        assertEquals(0D, exec("def x = (int)1 def y = (double)1 return x - y"));
+        assertEquals(0D, exec("def x = (long)1 def y = (double)1 return x - y"));
+        assertEquals(0D, exec("def x = (float)1 def y = (double)1 return x - y"));
+        assertEquals(0D, exec("def x = (double)1 def y = (double)1 return x - y"));
+
+        assertEquals(0, exec("def x = (Byte)1 def y = (byte)1 return x - y"));
+        assertEquals(0, exec("def x = (Short)1 def y = (short)1 return x - y"));
+        assertEquals(0, exec("def x = (Character)1 def y = (char)1 return x - y"));
+        assertEquals(0, exec("def x = (Integer)1 def y = (int)1 return x - y"));
+        assertEquals(0L, exec("def x = (Long)1 def y = (long)1 return x - y"));
+        assertEquals(0F, exec("def x = (Float)1 def y = (float)1 return x - y"));
+        assertEquals(0D, exec("def x = (Double)1 def y = (double)1 return x - y"));
+    }
+
+    public void testLsh() {
+        assertEquals(2, exec("def x = (byte)1 def y = (byte)1 return x << y"));
+        assertEquals(2, exec("def x = (short)1 def y = (byte)1 return x << y"));
+        assertEquals(2, exec("def x = (char)1 def y = (byte)1 return x << y"));
+        assertEquals(2, exec("def x = (int)1 def y = (byte)1 return x << y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (byte)1 return x << y"));
+        assertEquals(2L, exec("def x = (float)1 def y = (byte)1 return x << y"));
+        assertEquals(2L, exec("def x = (double)1 def y = (byte)1 return x << y"));
+
+        assertEquals(2, exec("def x = (byte)1 def y = (short)1 return x << y"));
+        assertEquals(2, exec("def x = (short)1 def y = (short)1 return x << y"));
+        assertEquals(2, exec("def x = (char)1 def y = (short)1 return x << y"));
+        assertEquals(2, exec("def x = (int)1 def y = (short)1 return x << y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (short)1 return x << y"));
+        assertEquals(2L, exec("def x = (float)1 def y = (short)1 return x << y"));
+        assertEquals(2L, exec("def x = (double)1 def y = (short)1 return x << y"));
+
+        assertEquals(2, exec("def x = (byte)1 def y = (char)1 return x << y"));
+        assertEquals(2, exec("def x = (short)1 def y = (char)1 return x << y"));
+        assertEquals(2, exec("def x = (char)1 def y = (char)1 return x << y"));
+        assertEquals(2, exec("def x = (int)1 def y = (char)1 return x << y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (char)1 return x << y"));
+        assertEquals(2L, exec("def x = (float)1 def y = (char)1 return x << y"));
+        assertEquals(2L, exec("def x = (double)1 def y = (char)1 return x << y"));
+
+        assertEquals(2, exec("def x = (byte)1 def y = (int)1 return x << y"));
+        assertEquals(2, exec("def x = (short)1 def y = (int)1 return x << y"));
+        assertEquals(2, exec("def x = (char)1 def y = (int)1 return x << y"));
+        assertEquals(2, exec("def x = (int)1 def y = (int)1 return x << y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (int)1 return x << y"));
+        assertEquals(2L, exec("def x = (float)1 def y = (int)1 return x << y"));
+        assertEquals(2L, exec("def x = (double)1 def y = (int)1 return x << y"));
+
+        assertEquals(2L, exec("def x = (byte)1 def y = (long)1 return x << y"));
+        assertEquals(2L, exec("def x = (short)1 def y = (long)1 return x << y"));
+        assertEquals(2L, exec("def x = (char)1 def y = (long)1 return x << y"));
+        assertEquals(2L, exec("def x = (int)1 def y = (long)1 return x << y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (long)1 return x << y"));
+        assertEquals(2L, exec("def x = (float)1 def y = (long)1 return x << y"));
+        assertEquals(2L, exec("def x = (double)1 def y = (long)1 return x << y"));
+
+        assertEquals(2L, exec("def x = (byte)1 def y = (float)1 return x << y"));
+        assertEquals(2L, exec("def x = (short)1 def y = (float)1 return x << y"));
+        assertEquals(2L, exec("def x = (char)1 def y = (float)1 return x << y"));
+        assertEquals(2L, exec("def x = (int)1 def y = (float)1 return x << y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (float)1 return x << y"));
+        assertEquals(2L, exec("def x = (float)1 def y = (float)1 return x << y"));
+        assertEquals(2L, exec("def x = (double)1 def y = (float)1 return x << y"));
+
+        assertEquals(2L, exec("def x = (byte)1 def y = (double)1 return x << y"));
+        assertEquals(2L, exec("def x = (short)1 def y = (double)1 return x << y"));
+        assertEquals(2L, exec("def x = (char)1 def y = (double)1 return x << y"));
+        assertEquals(2L, exec("def x = (int)1 def y = (double)1 return x << y"));
+        assertEquals(2L, exec("def x = (long)1 def y = (double)1 return x << y"));
+        assertEquals(2L, exec("def x = (float)1 def y = (double)1 return x << y"));
+        assertEquals(2L, exec("def x = (double)1 def y = (double)1 return x << y"));
+
+        assertEquals(2, exec("def x = (Byte)1 def y = (byte)1 return x << y"));
+        assertEquals(2, exec("def x = (Short)1 def y = (short)1 return x << y"));
+        assertEquals(2, exec("def x = (Character)1 def y = (char)1 return x << y"));
+        assertEquals(2, exec("def x = (Integer)1 def y = (int)1 return x << y"));
+        assertEquals(2L, exec("def x = (Long)1 def y = (long)1 return x << y"));
+        assertEquals(2L, exec("def x = (Float)1 def y = (float)1 return x << y"));
+        assertEquals(2L, exec("def x = (Double)1 def y = (double)1 return x << y"));
+    }
+
+    public void testRsh() {
+        assertEquals(2, exec("def x = (byte)4 def y = (byte)1 return x >> y"));
+        assertEquals(2, exec("def x = (short)4 def y = (byte)1 return x >> y"));
+        assertEquals(2, exec("def x = (char)4 def y = (byte)1 return x >> y"));
+        assertEquals(2, exec("def x = (int)4 def y = (byte)1 return x >> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (byte)1 return x >> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (byte)1 return x >> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (byte)1 return x >> y"));
+
+        assertEquals(2, exec("def x = (byte)4 def y = (short)1 return x >> y"));
+        assertEquals(2, exec("def x = (short)4 def y = (short)1 return x >> y"));
+        assertEquals(2, exec("def x = (char)4 def y = (short)1 return x >> y"));
+        assertEquals(2, exec("def x = (int)4 def y = (short)1 return x >> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (short)1 return x >> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (short)1 return x >> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (short)1 return x >> y"));
+
+        assertEquals(2, exec("def x = (byte)4 def y = (char)1 return x >> y"));
+        assertEquals(2, exec("def x = (short)4 def y = (char)1 return x >> y"));
+        assertEquals(2, exec("def x = (char)4 def y = (char)1 return x >> y"));
+        assertEquals(2, exec("def x = (int)4 def y = (char)1 return x >> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (char)1 return x >> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (char)1 return x >> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (char)1 return x >> y"));
+
+        assertEquals(2, exec("def x = (byte)4 def y = (int)1 return x >> y"));
+        assertEquals(2, exec("def x = (short)4 def y = (int)1 return x >> y"));
+        assertEquals(2, exec("def x = (char)4 def y = (int)1 return x >> y"));
+        assertEquals(2, exec("def x = (int)4 def y = (int)1 return x >> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (int)1 return x >> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (int)1 return x >> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (int)1 return x >> y"));
+
+        assertEquals(2L, exec("def x = (byte)4 def y = (long)1 return x >> y"));
+        assertEquals(2L, exec("def x = (short)4 def y = (long)1 return x >> y"));
+        assertEquals(2L, exec("def x = (char)4 def y = (long)1 return x >> y"));
+        assertEquals(2L, exec("def x = (int)4 def y = (long)1 return x >> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (long)1 return x >> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (long)1 return x >> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (long)1 return x >> y"));
+
+        assertEquals(2L, exec("def x = (byte)4 def y = (float)1 return x >> y"));
+        assertEquals(2L, exec("def x = (short)4 def y = (float)1 return x >> y"));
+        assertEquals(2L, exec("def x = (char)4 def y = (float)1 return x >> y"));
+        assertEquals(2L, exec("def x = (int)4 def y = (float)1 return x >> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (float)1 return x >> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (float)1 return x >> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (float)1 return x >> y"));
+
+        assertEquals(2L, exec("def x = (byte)4 def y = (double)1 return x >> y"));
+        assertEquals(2L, exec("def x = (short)4 def y = (double)1 return x >> y"));
+        assertEquals(2L, exec("def x = (char)4 def y = (double)1 return x >> y"));
+        assertEquals(2L, exec("def x = (int)4 def y = (double)1 return x >> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (double)1 return x >> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (double)1 return x >> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (double)1 return x >> y"));
+
+        assertEquals(2, exec("def x = (Byte)4 def y = (byte)1 return x >> y"));
+        assertEquals(2, exec("def x = (Short)4 def y = (short)1 return x >> y"));
+        assertEquals(2, exec("def x = (Character)4 def y = (char)1 return x >> y"));
+        assertEquals(2, exec("def x = (Integer)4 def y = (int)1 return x >> y"));
+        assertEquals(2L, exec("def x = (Long)4 def y = (long)1 return x >> y"));
+        assertEquals(2L, exec("def x = (Float)4 def y = (float)1 return x >> y"));
+        assertEquals(2L, exec("def x = (Double)4 def y = (double)1 return x >> y"));
+    }
+
+    public void testUsh() {
+        assertEquals(2, exec("def x = (byte)4 def y = (byte)1 return x >>> y"));
+        assertEquals(2, exec("def x = (short)4 def y = (byte)1 return x >>> y"));
+        assertEquals(2, exec("def x = (char)4 def y = (byte)1 return x >>> y"));
+        assertEquals(2, exec("def x = (int)4 def y = (byte)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (byte)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (byte)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (byte)1 return x >>> y"));
+
+        assertEquals(2, exec("def x = (byte)4 def y = (short)1 return x >>> y"));
+        assertEquals(2, exec("def x = (short)4 def y = (short)1 return x >>> y"));
+        assertEquals(2, exec("def x = (char)4 def y = (short)1 return x >>> y"));
+        assertEquals(2, exec("def x = (int)4 def y = (short)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (short)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (short)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (short)1 return x >>> y"));
+
+        assertEquals(2, exec("def x = (byte)4 def y = (char)1 return x >>> y"));
+        assertEquals(2, exec("def x = (short)4 def y = (char)1 return x >>> y"));
+        assertEquals(2, exec("def x = (char)4 def y = (char)1 return x >>> y"));
+        assertEquals(2, exec("def x = (int)4 def y = (char)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (char)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (char)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (char)1 return x >>> y"));
+
+        assertEquals(2, exec("def x = (byte)4 def y = (int)1 return x >>> y"));
+        assertEquals(2, exec("def x = (short)4 def y = (int)1 return x >>> y"));
+        assertEquals(2, exec("def x = (char)4 def y = (int)1 return x >>> y"));
+        assertEquals(2, exec("def x = (int)4 def y = (int)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (int)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (int)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (int)1 return x >>> y"));
+
+        assertEquals(2L, exec("def x = (byte)4 def y = (long)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (short)4 def y = (long)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (char)4 def y = (long)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (int)4 def y = (long)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (long)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (long)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (long)1 return x >>> y"));
+
+        assertEquals(2L, exec("def x = (byte)4 def y = (float)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (short)4 def y = (float)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (char)4 def y = (float)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (int)4 def y = (float)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (float)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (float)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (float)1 return x >>> y"));
+
+        assertEquals(2L, exec("def x = (byte)4 def y = (double)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (short)4 def y = (double)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (char)4 def y = (double)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (int)4 def y = (double)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (long)4 def y = (double)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (float)4 def y = (double)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (double)4 def y = (double)1 return x >>> y"));
+
+        assertEquals(2, exec("def x = (Byte)4 def y = (byte)1 return x >>> y"));
+        assertEquals(2, exec("def x = (Short)4 def y = (short)1 return x >>> y"));
+        assertEquals(2, exec("def x = (Character)4 def y = (char)1 return x >>> y"));
+        assertEquals(2, exec("def x = (Integer)4 def y = (int)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (Long)4 def y = (long)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (Float)4 def y = (float)1 return x >>> y"));
+        assertEquals(2L, exec("def x = (Double)4 def y = (double)1 return x >>> y"));
+    }
+
+    public void testAnd() {
+        assertEquals(0, exec("def x = (byte)4 def y = (byte)1 return x & y"));
+        assertEquals(0, exec("def x = (short)4 def y = (byte)1 return x & y"));
+        assertEquals(0, exec("def x = (char)4 def y = (byte)1 return x & y"));
+        assertEquals(0, exec("def x = (int)4 def y = (byte)1 return x & y"));
+        assertEquals(0L, exec("def x = (long)4 def y = (byte)1 return x & y"));
+        assertEquals(0L, exec("def x = (float)4 def y = (byte)1 return x & y"));
+        assertEquals(0L, exec("def x = (double)4 def y = (byte)1 return x & y"));
+
+        assertEquals(0, exec("def x = (byte)4 def y = (short)1 return x & y"));
+        assertEquals(0, exec("def x = (short)4 def y = (short)1 return x & y"));
+        assertEquals(0, exec("def x = (char)4 def y = (short)1 return x & y"));
+        assertEquals(0, exec("def x = (int)4 def y = (short)1 return x & y"));
+        assertEquals(0L, exec("def x = (long)4 def y = (short)1 return x & y"));
+        assertEquals(0L, exec("def x = (float)4 def y = (short)1 return x & y"));
+        assertEquals(0L, exec("def x = (double)4 def y = (short)1 return x & y"));
+
+        assertEquals(0, exec("def x = (byte)4 def y = (char)1 return x & y"));
+        assertEquals(0, exec("def x = (short)4 def y = (char)1 return x & y"));
+        assertEquals(0, exec("def x = (char)4 def y = (char)1 return x & y"));
+        assertEquals(0, exec("def x = (int)4 def y = (char)1 return x & y"));
+        assertEquals(0L, exec("def x = (long)4 def y = (char)1 return x & y"));
+        assertEquals(0L, exec("def x = (float)4 def y = (char)1 return x & y"));
+        assertEquals(0L, exec("def x = (double)4 def y = (char)1 return x & y"));
+
+        assertEquals(0, exec("def x = (byte)4 def y = (int)1 return x & y"));
+        assertEquals(0, exec("def x = (short)4 def y = (int)1 return x & y"));
+        assertEquals(0, exec("def x = (char)4 def y = (int)1 return x & y"));
+        assertEquals(0, exec("def x = (int)4 def y = (int)1 return x & y"));
+        assertEquals(0L, exec("def x = (long)4 def y = (int)1 return x & y"));
+        assertEquals(0L, exec("def x = (float)4 def y = (int)1 return x & y"));
+        assertEquals(0L, exec("def x = (double)4 def y = (int)1 return x & y"));
+
+        assertEquals(0L, exec("def x = (byte)4 def y = (long)1 return x & y"));
+        assertEquals(0L, exec("def x = (short)4 def y = (long)1 return x & y"));
+        assertEquals(0L, exec("def x = (char)4 def y = (long)1 return x & y"));
+        assertEquals(0L, exec("def x = (int)4 def y = (long)1 return x & y"));
+        assertEquals(0L, exec("def x = (long)4 def y = (long)1 return x & y"));
+        assertEquals(0L, exec("def x = (float)4 def y = (long)1 return x & y"));
+        assertEquals(0L, exec("def x = (double)4 def y = (long)1 return x & y"));
+
+        assertEquals(0L, exec("def x = (byte)4 def y = (float)1 return x & y"));
+        assertEquals(0L, exec("def x = (short)4 def y = (float)1 return x & y"));
+        assertEquals(0L, exec("def x = (char)4 def y = (float)1 return x & y"));
+        assertEquals(0L, exec("def x = (int)4 def y = (float)1 return x & y"));
+        assertEquals(0L, exec("def x = (long)4 def y = (float)1 return x & y"));
+        assertEquals(0L, exec("def x = (float)4 def y = (float)1 return x & y"));
+        assertEquals(0L, exec("def x = (double)4 def y = (float)1 return x & y"));
+
+        assertEquals(0L, exec("def x = (byte)4 def y = (double)1 return x & y"));
+        assertEquals(0L, exec("def x = (short)4 def y = (double)1 return x & y"));
+        assertEquals(0L, exec("def x = (char)4 def y = (double)1 return x & y"));
+        assertEquals(0L, exec("def x = (int)4 def y = (double)1 return x & y"));
+        assertEquals(0L, exec("def x = (long)4 def y = (double)1 return x & y"));
+        assertEquals(0L, exec("def x = (float)4 def y = (double)1 return x & y"));
+        assertEquals(0L, exec("def x = (double)4 def y = (double)1 return x & y"));
+
+        assertEquals(0, exec("def x = (Byte)4 def y = (byte)1 return x & y"));
+        assertEquals(0, exec("def x = (Short)4 def y = (short)1 return x & y"));
+        assertEquals(0, exec("def x = (Character)4 def y = (char)1 return x & y"));
+        assertEquals(0, exec("def x = (Integer)4 def y = (int)1 return x & y"));
+        assertEquals(0L, exec("def x = (Long)4 def y = (long)1 return x & y"));
+        assertEquals(0L, exec("def x = (Float)4 def y = (float)1 return x & y"));
+        assertEquals(0L, exec("def x = (Double)4 def y = (double)1 return x & y"));
+    }
+
+    public void testXor() {
+        assertEquals(5, exec("def x = (byte)4 def y = (byte)1 return x ^ y"));
+        assertEquals(5, exec("def x = (short)4 def y = (byte)1 return x ^ y"));
+        assertEquals(5, exec("def x = (char)4 def y = (byte)1 return x ^ y"));
+        assertEquals(5, exec("def x = (int)4 def y = (byte)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (byte)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (byte)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (byte)1 return x ^ y"));
+
+        assertEquals(5, exec("def x = (byte)4 def y = (short)1 return x ^ y"));
+        assertEquals(5, exec("def x = (short)4 def y = (short)1 return x ^ y"));
+        assertEquals(5, exec("def x = (char)4 def y = (short)1 return x ^ y"));
+        assertEquals(5, exec("def x = (int)4 def y = (short)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (short)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (short)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (short)1 return x ^ y"));
+
+        assertEquals(5, exec("def x = (byte)4 def y = (char)1 return x ^ y"));
+        assertEquals(5, exec("def x = (short)4 def y = (char)1 return x ^ y"));
+        assertEquals(5, exec("def x = (char)4 def y = (char)1 return x ^ y"));
+        assertEquals(5, exec("def x = (int)4 def y = (char)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (char)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (char)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (char)1 return x ^ y"));
+
+        assertEquals(5, exec("def x = (byte)4 def y = (int)1 return x ^ y"));
+        assertEquals(5, exec("def x = (short)4 def y = (int)1 return x ^ y"));
+        assertEquals(5, exec("def x = (char)4 def y = (int)1 return x ^ y"));
+        assertEquals(5, exec("def x = (int)4 def y = (int)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (int)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (int)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (int)1 return x ^ y"));
+
+        assertEquals(5L, exec("def x = (byte)4 def y = (long)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (short)4 def y = (long)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (char)4 def y = (long)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (int)4 def y = (long)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (long)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (long)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (long)1 return x ^ y"));
+
+        assertEquals(5L, exec("def x = (byte)4 def y = (float)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (short)4 def y = (float)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (char)4 def y = (float)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (int)4 def y = (float)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (float)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (float)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (float)1 return x ^ y"));
+
+        assertEquals(5L, exec("def x = (byte)4 def y = (double)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (short)4 def y = (double)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (char)4 def y = (double)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (int)4 def y = (double)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (double)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (double)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (double)1 return x ^ y"));
+
+        assertEquals(5, exec("def x = (Byte)4 def y = (byte)1 return x ^ y"));
+        assertEquals(5, exec("def x = (Short)4 def y = (short)1 return x ^ y"));
+        assertEquals(5, exec("def x = (Character)4 def y = (char)1 return x ^ y"));
+        assertEquals(5, exec("def x = (Integer)4 def y = (int)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (Long)4 def y = (long)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (Float)4 def y = (float)1 return x ^ y"));
+        assertEquals(5L, exec("def x = (Double)4 def y = (double)1 return x ^ y"));
+    }
+
+    public void testOr() {
+        assertEquals(5, exec("def x = (byte)4 def y = (byte)1 return x | y"));
+        assertEquals(5, exec("def x = (short)4 def y = (byte)1 return x | y"));
+        assertEquals(5, exec("def x = (char)4 def y = (byte)1 return x | y"));
+        assertEquals(5, exec("def x = (int)4 def y = (byte)1 return x | y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (byte)1 return x | y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (byte)1 return x | y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (byte)1 return x | y"));
+
+        assertEquals(5, exec("def x = (byte)4 def y = (short)1 return x | y"));
+        assertEquals(5, exec("def x = (short)4 def y = (short)1 return x | y"));
+        assertEquals(5, exec("def x = (char)4 def y = (short)1 return x | y"));
+        assertEquals(5, exec("def x = (int)4 def y = (short)1 return x | y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (short)1 return x | y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (short)1 return x | y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (short)1 return x | y"));
+
+        assertEquals(5, exec("def x = (byte)4 def y = (char)1 return x | y"));
+        assertEquals(5, exec("def x = (short)4 def y = (char)1 return x | y"));
+        assertEquals(5, exec("def x = (char)4 def y = (char)1 return x | y"));
+        assertEquals(5, exec("def x = (int)4 def y = (char)1 return x | y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (char)1 return x | y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (char)1 return x | y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (char)1 return x | y"));
+
+        assertEquals(5, exec("def x = (byte)4 def y = (int)1 return x | y"));
+        assertEquals(5, exec("def x = (short)4 def y = (int)1 return x | y"));
+        assertEquals(5, exec("def x = (char)4 def y = (int)1 return x | y"));
+        assertEquals(5, exec("def x = (int)4 def y = (int)1 return x | y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (int)1 return x | y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (int)1 return x | y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (int)1 return x | y"));
+
+        assertEquals(5L, exec("def x = (byte)4 def y = (long)1 return x | y"));
+        assertEquals(5L, exec("def x = (short)4 def y = (long)1 return x | y"));
+        assertEquals(5L, exec("def x = (char)4 def y = (long)1 return x | y"));
+        assertEquals(5L, exec("def x = (int)4 def y = (long)1 return x | y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (long)1 return x | y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (long)1 return x | y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (long)1 return x | y"));
+
+        assertEquals(5L, exec("def x = (byte)4 def y = (float)1 return x | y"));
+        assertEquals(5L, exec("def x = (short)4 def y = (float)1 return x | y"));
+        assertEquals(5L, exec("def x = (char)4 def y = (float)1 return x | y"));
+        assertEquals(5L, exec("def x = (int)4 def y = (float)1 return x | y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (float)1 return x | y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (float)1 return x | y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (float)1 return x | y"));
+
+        assertEquals(5L, exec("def x = (byte)4 def y = (double)1 return x | y"));
+        assertEquals(5L, exec("def x = (short)4 def y = (double)1 return x | y"));
+        assertEquals(5L, exec("def x = (char)4 def y = (double)1 return x | y"));
+        assertEquals(5L, exec("def x = (int)4 def y = (double)1 return x | y"));
+        assertEquals(5L, exec("def x = (long)4 def y = (double)1 return x | y"));
+        assertEquals(5L, exec("def x = (float)4 def y = (double)1 return x | y"));
+        assertEquals(5L, exec("def x = (double)4 def y = (double)1 return x | y"));
+
+        assertEquals(5, exec("def x = (Byte)4 def y = (byte)1 return x | y"));
+        assertEquals(5, exec("def x = (Short)4 def y = (short)1 return x | y"));
+        assertEquals(5, exec("def x = (Character)4 def y = (char)1 return x | y"));
+        assertEquals(5, exec("def x = (Integer)4 def y = (int)1 return x | y"));
+        assertEquals(5L, exec("def x = (Long)4 def y = (long)1 return x | y"));
+        assertEquals(5L, exec("def x = (Float)4 def y = (float)1 return x | y"));
+        assertEquals(5L, exec("def x = (Double)4 def y = (double)1 return x | y"));
+    }
+
+    public void testEq() {
+        assertEquals(true, exec("def x = (byte)7 def y = (int)7 return x == y"));
+        assertEquals(true, exec("def x = (short)6 def y = (int)6 return x == y"));
+        assertEquals(true, exec("def x = (char)5 def y = (int)5 return x == y"));
+        assertEquals(true, exec("def x = (int)4 def y = (int)4 return x == y"));
+        assertEquals(false, exec("def x = (long)5 def y = (int)3 return x == y"));
+        assertEquals(false, exec("def x = (float)6 def y = (int)2 return x == y"));
+        assertEquals(false, exec("def x = (double)7 def y = (int)1 return x == y"));
+
+        assertEquals(true, exec("def x = (byte)7 def y = (double)7 return x == y"));
+        assertEquals(true, exec("def x = (short)6 def y = (double)6 return x == y"));
+        assertEquals(true, exec("def x = (char)5 def y = (double)5 return x == y"));
+        assertEquals(true, exec("def x = (int)4 def y = (double)4 return x == y"));
+        assertEquals(false, exec("def x = (long)5 def y = (double)3 return x == y"));
+        assertEquals(false, exec("def x = (float)6 def y = (double)2 return x == y"));
+        assertEquals(false, exec("def x = (double)7 def y = (double)1 return x == y"));
+
+        assertEquals(true, exec("def x = new HashMap() def y = new HashMap() return x == y"));
+        assertEquals(false, exec("def x = new HashMap() x.put(3, 3) def y = new HashMap() return x == y"));
+        assertEquals(true, exec("def x = new HashMap() x.put(3, 3) def y = new HashMap() y.put(3, 3) return x == y"));
+        assertEquals(true, exec("def x = new HashMap() def y = x x.put(3, 3) y.put(3, 3) return x == y"));
+    }
+
+    public void testEqr() {
+        assertEquals(false, exec("def x = (byte)7 def y = (int)7 return x === y"));
+        assertEquals(false, exec("def x = (short)6 def y = (int)6 return x === y"));
+        assertEquals(false, exec("def x = (char)5 def y = (int)5 return x === y"));
+        assertEquals(true, exec("def x = (int)4 def y = (int)4 return x === y"));
+        assertEquals(false, exec("def x = (long)5 def y = (int)3 return x === y"));
+        assertEquals(false, exec("def x = (float)6 def y = (int)2 return x === y"));
+        assertEquals(false, exec("def x = (double)7 def y = (int)1 return x === y"));
+
+        assertEquals(false, exec("def x = new HashMap() def y = new HashMap() return x === y"));
+        assertEquals(false, exec("def x = new HashMap() x.put(3, 3) def y = new HashMap() return x === y"));
+        assertEquals(false, exec("def x = new HashMap() x.put(3, 3) def y = new HashMap() y.put(3, 3) return x === y"));
+        assertEquals(true, exec("def x = new HashMap() def y = x x.put(3, 3) y.put(3, 3) return x === y"));
+    }
+
+    public void testNe() {
+        assertEquals(false, exec("def x = (byte)7 def y = (int)7 return x != y"));
+        assertEquals(false, exec("def x = (short)6 def y = (int)6 return x != y"));
+        assertEquals(false, exec("def x = (char)5 def y = (int)5 return x != y"));
+        assertEquals(false, exec("def x = (int)4 def y = (int)4 return x != y"));
+        assertEquals(true, exec("def x = (long)5 def y = (int)3 return x != y"));
+        assertEquals(true, exec("def x = (float)6 def y = (int)2 return x != y"));
+        assertEquals(true, exec("def x = (double)7 def y = (int)1 return x != y"));
+
+        assertEquals(false, exec("def x = (byte)7 def y = (double)7 return x != y"));
+        assertEquals(false, exec("def x = (short)6 def y = (double)6 return x != y"));
+        assertEquals(false, exec("def x = (char)5 def y = (double)5 return x != y"));
+        assertEquals(false, exec("def x = (int)4 def y = (double)4 return x != y"));
+        assertEquals(true, exec("def x = (long)5 def y = (double)3 return x != y"));
+        assertEquals(true, exec("def x = (float)6 def y = (double)2 return x != y"));
+        assertEquals(true, exec("def x = (double)7 def y = (double)1 return x != y"));
+
+        assertEquals(false, exec("def x = new HashMap() def y = new HashMap() return x != y"));
+        assertEquals(true, exec("def x = new HashMap() x.put(3, 3) def y = new HashMap() return x != y"));
+        assertEquals(false, exec("def x = new HashMap() x.put(3, 3) def y = new HashMap() y.put(3, 3) return x != y"));
+        assertEquals(false, exec("def x = new HashMap() def y = x x.put(3, 3) y.put(3, 3) return x != y"));
+    }
+
+    public void testNer() {
+        assertEquals(true, exec("def x = (byte)7 def y = (int)7 return x !== y"));
+        assertEquals(true, exec("def x = (short)6 def y = (int)6 return x !== y"));
+        assertEquals(true, exec("def x = (char)5 def y = (int)5 return x !== y"));
+        assertEquals(false, exec("def x = (int)4 def y = (int)4 return x !== y"));
+        assertEquals(true, exec("def x = (long)5 def y = (int)3 return x !== y"));
+        assertEquals(true, exec("def x = (float)6 def y = (int)2 return x !== y"));
+        assertEquals(true, exec("def x = (double)7 def y = (int)1 return x !== y"));
+
+        assertEquals(true, exec("def x = new HashMap() def y = new HashMap() return x !== y"));
+        assertEquals(true, exec("def x = new HashMap() x.put(3, 3) def y = new HashMap() return x !== y"));
+        assertEquals(true, exec("def x = new HashMap() x.put(3, 3) def y = new HashMap() y.put(3, 3) return x !== y"));
+        assertEquals(false, exec("def x = new HashMap() def y = x x.put(3, 3) y.put(3, 3) return x !== y"));
+    }
+
+    public void testLt() {
+        assertEquals(true, exec("def x = (byte)1 def y = (int)7 return x < y"));
+        assertEquals(true, exec("def x = (short)2 def y = (int)6 return x < y"));
+        assertEquals(true, exec("def x = (char)3 def y = (int)5 return x < y"));
+        assertEquals(false, exec("def x = (int)4 def y = (int)4 return x < y"));
+        assertEquals(false, exec("def x = (long)5 def y = (int)3 return x < y"));
+        assertEquals(false, exec("def x = (float)6 def y = (int)2 return x < y"));
+        assertEquals(false, exec("def x = (double)7 def y = (int)1 return x < y"));
+
+        assertEquals(true, exec("def x = (byte)1 def y = (double)7 return x < y"));
+        assertEquals(true, exec("def x = (short)2 def y = (double)6 return x < y"));
+        assertEquals(true, exec("def x = (char)3 def y = (double)5 return x < y"));
+        assertEquals(false, exec("def x = (int)4 def y = (double)4 return x < y"));
+        assertEquals(false, exec("def x = (long)5 def y = (double)3 return x < y"));
+        assertEquals(false, exec("def x = (float)6 def y = (double)2 return x < y"));
+        assertEquals(false, exec("def x = (double)7 def y = (double)1 return x < y"));
+    }
+
+    public void testLte() {
+        assertEquals(true, exec("def x = (byte)1 def y = (int)7 return x <= y"));
+        assertEquals(true, exec("def x = (short)2 def y = (int)6 return x <= y"));
+        assertEquals(true, exec("def x = (char)3 def y = (int)5 return x <= y"));
+        assertEquals(true, exec("def x = (int)4 def y = (int)4 return x <= y"));
+        assertEquals(false, exec("def x = (long)5 def y = (int)3 return x <= y"));
+        assertEquals(false, exec("def x = (float)6 def y = (int)2 return x <= y"));
+        assertEquals(false, exec("def x = (double)7 def y = (int)1 return x <= y"));
+
+        assertEquals(true, exec("def x = (byte)1 def y = (double)7 return x <= y"));
+        assertEquals(true, exec("def x = (short)2 def y = (double)6 return x <= y"));
+        assertEquals(true, exec("def x = (char)3 def y = (double)5 return x <= y"));
+        assertEquals(true, exec("def x = (int)4 def y = (double)4 return x <= y"));
+        assertEquals(false, exec("def x = (long)5 def y = (double)3 return x <= y"));
+        assertEquals(false, exec("def x = (float)6 def y = (double)2 return x <= y"));
+        assertEquals(false, exec("def x = (double)7 def y = (double)1 return x <= y"));
+    }
+
+    public void testGt() {
+        assertEquals(false, exec("def x = (byte)1 def y = (int)7 return x > y"));
+        assertEquals(false, exec("def x = (short)2 def y = (int)6 return x > y"));
+        assertEquals(false, exec("def x = (char)3 def y = (int)5 return x > y"));
+        assertEquals(false, exec("def x = (int)4 def y = (int)4 return x > y"));
+        assertEquals(true, exec("def x = (long)5 def y = (int)3 return x > y"));
+        assertEquals(true, exec("def x = (float)6 def y = (int)2 return x > y"));
+        assertEquals(true, exec("def x = (double)7 def y = (int)1 return x > y"));
+
+        assertEquals(false, exec("def x = (byte)1 def y = (double)7 return x > y"));
+        assertEquals(false, exec("def x = (short)2 def y = (double)6 return x > y"));
+        assertEquals(false, exec("def x = (char)3 def y = (double)5 return x > y"));
+        assertEquals(false, exec("def x = (int)4 def y = (double)4 return x > y"));
+        assertEquals(true, exec("def x = (long)5 def y = (double)3 return x > y"));
+        assertEquals(true, exec("def x = (float)6 def y = (double)2 return x > y"));
+        assertEquals(true, exec("def x = (double)7 def y = (double)1 return x > y"));
+    }
+
+    public void testGte() {
+        assertEquals(false, exec("def x = (byte)1 def y = (int)7 return x >= y"));
+        assertEquals(false, exec("def x = (short)2 def y = (int)6 return x >= y"));
+        assertEquals(false, exec("def x = (char)3 def y = (int)5 return x >= y"));
+        assertEquals(true, exec("def x = (int)4 def y = (int)4 return x >= y"));
+        assertEquals(true, exec("def x = (long)5 def y = (int)3 return x >= y"));
+        assertEquals(true, exec("def x = (float)6 def y = (int)2 return x >= y"));
+        assertEquals(true, exec("def x = (double)7 def y = (int)1 return x >= y"));
+
+        assertEquals(false, exec("def x = (byte)1 def y = (double)7 return x >= y"));
+        assertEquals(false, exec("def x = (short)2 def y = (double)6 return x >= y"));
+        assertEquals(false, exec("def x = (char)3 def y = (double)5 return x >= y"));
+        assertEquals(true, exec("def x = (int)4 def y = (double)4 return x >= y"));
+        assertEquals(true, exec("def x = (long)5 def y = (double)3 return x >= y"));
+        assertEquals(true, exec("def x = (float)6 def y = (double)2 return x >= y"));
+        assertEquals(true, exec("def x = (double)7 def y = (double)1 return x >= y"));
+    }
+}

--- a/src/test/java/org/elasticsearch/plan/a/FieldTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/FieldTests.java
@@ -66,7 +66,7 @@ public class FieldTests extends ScriptTestCase {
     }
 
     public void testIntField() {
-        assertEquals("s5.0t42", exec("def fc = new FieldClass() return fc.t += 2 + fc.j + \"t\" + 4 + (3 - 1)"));
+        assertEquals("s5t42", exec("def fc = new FieldClass() return fc.t += 2 + fc.j + \"t\" + 4 + (3 - 1)"));
         assertEquals(2.0f, exec("def fc = new FieldClass(); def l = new Double(3) Byte b = new Byte((byte)2) return fc.test(l, b)"));
         assertEquals(4, exec("def fc = new FieldClass() fc.i = 4 return fc.i"));
         assertEquals(5, exec("FieldClass fc0 = new FieldClass() FieldClass fc1 = new FieldClass() fc0.i = 7 - fc0.i fc1.i = fc0.i return fc1.i"));

--- a/src/test/java/org/elasticsearch/plan/a/StringTests.java
+++ b/src/test/java/org/elasticsearch/plan/a/StringTests.java
@@ -58,5 +58,18 @@ public class StringTests extends ScriptTestCase {
         assertEquals("e", exec("String t = \"abcde\"; return t.substring(4, 5);"));
         assertEquals(97, ((char[])exec("String s = \"a\"; return s.toCharArray();"))[0]);
         assertEquals("a", exec("String s = \" a \"; return s.trim();"));
+        assertEquals('x', exec("return \"x\".charAt(0);"));
+        assertEquals(120, exec("return \"x\".codePointAt(0);"));
+        assertEquals(0, exec("return \"x\".compareTo(\"x\");"));
+        assertEquals("xx", exec("return \"x\".concat(\"x\");"));
+        assertEquals(true, exec("return \"xy\".endsWith(\"y\");"));
+        assertEquals(2, exec("return \"abcde\".indexOf(\"cd\", 1);"));
+        assertEquals(false, exec("return \"abcde\".isEmpty();"));
+        assertEquals(5, exec("return \"abcde\".length();"));
+        assertEquals("cdcde", exec("return \"abcde\".replace(\"ab\", \"cd\");"));
+        assertEquals(false, exec("return \"xy\".startsWith(\"y\");"));
+        assertEquals("e", exec("return \"abcde\".substring(4, 5);"));
+        assertEquals(97, ((char[])exec("return \"a\".toCharArray();"))[0]);
+        assertEquals("a", exec("return \" a \".trim();"));
     }
 }


### PR DESCRIPTION
* Allow string constants to be used with method such as "x".equals("x")
* Added new tests for the string constants.
* Separate variable from field at the grammar level to give them separate nodes in the tree for processing.